### PR TITLE
MongoDB 3.6 Support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -312,6 +312,9 @@ functions:
           # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
           PROJECT_DIRECTORY=${PROJECT_DIRECTORY} NEXUS_USERNAME=${nexus_username} NEXUS_PASSWORD=${nexus_password} SIGNING_PASSWORD=${signing_password} SIGNING_KEY_ID=${signing_key_id} RING_FILE_GPG_BASE64=${ring_file_gpg_base64} .evergreen/publish-snapshots.sh
 
+hosts: &hosts
+ - rhel62-small
+ - rhel70-small
 
 pre:
   - func: "fetch source"
@@ -350,7 +353,7 @@ tasks:
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
-            VERSION: "3.4"
+            VERSION: "3.6"
             TOPOLOGY: "server"
         - func: "run coverage"
         - func: "upload build"
@@ -374,16 +377,16 @@ axes:
   - id: "version"
     display_name: "MongoDB Version"
     values:
-      - id: "3.4"
-        display_name: "3.4"
+      - id: "3.6"
+        display_name: "3.6"
         variables:
-           VERSION: "3.4"
-  - id: "os"
-    display_name: "OS"
+           VERSION: "3.6"
+  - id: os
+    display_name: OS
     values:
-      - id: "rhel62"
-        display_name: "RHEL 6.2"
-        run_on: "rhel62-test"
+      - id: "linux"
+        display_name: "Linux"
+        run_on: *hosts
 
   - id: "topology"
     display_name: "Topology"
@@ -404,6 +407,18 @@ axes:
         display_name: "2.12"
         variables:
            SCALA_VERSION: "2.12.2"
+
+    - id: "streamType"
+      display_name: "streamType"
+      values:
+        - id: "nio2"
+          display_name: "NIO2"
+          variables:
+             STREAM_TYPE: "nio2"
+        - id: "netty"
+          display_name: "Netty"
+          variables:
+             STREAM_TYPE: "netty"
 
 buildvariants:
 
@@ -429,8 +444,8 @@ buildvariants:
     - name: "coverage-task"
 
 - matrix_name: "integration-tests"
-  matrix_spec: { scalaVersion: "*", version: "*", topology: "*", os: "*" }
-  display_name: "Int: ${scalaVersion} ${version} ${topology} ${os}"
+  matrix_spec: { scalaVersion: "*", version: "*", topology: "*", os: "*",  streamType: "*"}
+  display_name: "Int: ${scalaVersion} ${version} ${topology} ${os} ${streamType}"
   tags: ["integration-test"]
   tasks:
      - name: "integration-test-task"
@@ -438,6 +453,6 @@ buildvariants:
 - name: "publish-snapshots"
   display_name: "Publish Snapshots"
   run_on:
-    - "rhel62-test"
+    - *hosts
   tasks:
     - name: "publish-snapshots-task"

--- a/.evergreen/run-it-tests.sh
+++ b/.evergreen/run-it-tests.sh
@@ -5,12 +5,14 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
+#       STREAM_TYPE             The async stream type to test with
 #       TOPOLOGY                Allows you to modify variables and the MONGODB_URI based on test topology
 #                               Supported values: "server", "replica_set", "sharded_cluster"
 #       SCALA_VERSION           Set the version of Scala to be used.
 
 
 MONGODB_URI=${MONGODB_URI:-}
+STREAM_TYPE=${STREAM_TYPE:-}
 TOPOLOGY=${TOPOLOGY:-server}
 JAVA_HOME="/opt/java/jdk8"
 
@@ -20,7 +22,12 @@ JAVA_HOME="/opt/java/jdk8"
 
 # Provision the correct connection string
 if [ "$TOPOLOGY" == "sharded_cluster" ]; then
-    MONGODB_URI="mongodb://localhost:27017"
+    export MONGODB_URI="mongodb://localhost:27017"
+fi
+if [ "$TOPOLOGY" == "replica_set" ]; then
+    export MONGODB_URI="${MONGODB_URI}&streamType=${STREAM_TYPE}"
+  else
+    export MONGODB_URI="${MONGODB_URI}/streamType=${STREAM_TYPE}"
 fi
 
 echo "Running Integration tests for Scala $SCALA_VERSION, $TOPOLOGY and connecting to $MONGODB_URI"

--- a/docs/landing/data/releases.toml
+++ b/docs/landing/data/releases.toml
@@ -1,19 +1,22 @@
 driverName = "mongo-scala-driver"
 githubRepo = "mongo-scala-driver"
-current = "2.1.0"
+current = "2.2.0"
+
+[[versions]]
+  version = "2.2.0"
+  status = "current"
+  docs = "./2.2"
+  api = "./2.2/scaladoc"
 
 [[versions]]
   version = "2.1.0"
-  status = "current"
   docs = "./2.1"
   api = "./2.1/scaladoc"
-
 
 [[versions]]
   version = "2.0.0"
   docs = "./2.0"
   api = "./2.0/scaladoc"
-
 
 [[versions]]
   version = "1.2.1"

--- a/docs/landing/static/versions.json
+++ b/docs/landing/static/versions.json
@@ -1,1 +1,1 @@
-[{"version": "2.1"}, {"version": "2.0"}, {"version": "1.2"}, {"version": "1.1"}, {"version": "1.0"}]
+[{"version": "2.2"}, {"version": "2.1"}, {"version": "2.0"}, {"version": "1.2"}, {"version": "1.1"}, {"version": "1.0"}]

--- a/docs/reference/config.toml
+++ b/docs/reference/config.toml
@@ -1,4 +1,4 @@
-baseurl = "/mongo-scala-driver/2.1"
+baseurl = "/mongo-scala-driver/2.2"
 languageCode = "en-us"
 title = "MongoDB Scala Driver"
 theme = "mongodb"

--- a/docs/reference/content/changelog.md
+++ b/docs/reference/content/changelog.md
@@ -12,6 +12,9 @@ Changes between released versions
 
 ### 2.2.0
 
+  * Updated MongoDB Driver Async to 3.6.0
+  * MongoDB 3.6 support [SCALA-336](https://jira.mongodb.org/browse/SCALA-336)
+    See the [what's new in 3.6 guide](http://mongodb.github.io/mongo-java-driver/3.6/whats-new/)
   * Fixed exception handling in Macro Codecs [SCALA-319](https://jira.mongodb.org/browse/SCALA-319)
   * Added implicit headOption method [SCALA-334](https://jira.mongodb.org/browse/SCALA-334)
   * Added BsonProperty annotation [SCALA-321](https://jira.mongodb.org/browse/SCALA-321)

--- a/docs/reference/content/getting-started/installation-guide.md
+++ b/docs/reference/content/getting-started/installation-guide.md
@@ -19,8 +19,8 @@ The MongoDB Scala Driver
 
 ### Scala 2.12
 
-{{< install artifactId="mongo-scala-driver" version="2.1.0" mongoDriverVersion="3.4.2" scalaVersion="2.12">}}
+{{< install artifactId="mongo-scala-driver" version="2.2.0" mongoDriverVersion="3.6.0" scalaVersion="2.12">}}
 
 ### Scala 2.11
 
-{{< install artifactId="mongo-scala-driver" version="2.1.0" mongoDriverVersion="3.4.2" scalaVersion="2.11">}}
+{{< install artifactId="mongo-scala-driver" version="2.2.0" mongoDriverVersion="3.6.0" scalaVersion="2.11">}}

--- a/docs/reference/data/mongodb.toml
+++ b/docs/reference/data/mongodb.toml
@@ -1,9 +1,9 @@
 githubUser = "mongodb"
 githubRepo = "mongo-scala-driver"
 githubBranch = "master"
-currentVersion = "2.1"
+currentVersion = "2.2"
 highlightTheme = "idea.css"
 apiUrl = "/scaladoc/index.html"
-coreApiUrl = "http://api.mongodb.org/java/3.4/"
-coreDocsUrl = "http://mongodb.github.io/mongo-java-driver/3.4/"
-mongoDriverVersion = "3.4.2"               # Update in installation-guide.md
+coreApiUrl = "http://mongodb.github.io/mongo-java-driver/3.6/javadoc"
+coreDocsUrl = "http://mongodb.github.io/mongo-java-driver/3.6/"
+mongoDriverVersion = "3.6.0"               # Update in installation-guide.md

--- a/driver/src/it/scala/org/mongodb/scala/DocumentationChangeStreamExampleSpec.scala
+++ b/driver/src/it/scala/org/mongodb/scala/DocumentationChangeStreamExampleSpec.scala
@@ -1,0 +1,172 @@
+package org.mongodb.scala
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
+
+import com.mongodb.client.model.changestream.FullDocument
+import org.mongodb.scala.model.{Aggregates, Filters, Updates}
+import org.mongodb.scala.model.changestream.ChangeStreamDocument
+
+import scala.collection.mutable
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+//scalastyle:off magic.number regex
+class DocumentationChangeStreamExampleSpec extends RequiresMongoDBISpec {
+
+  "The Scala driver" should "be able to use $changeStreams" in withCollection { collection =>
+    assume(serverVersionAtLeast(List(3, 6, 0)) && !hasSingleHost())
+
+    /*
+     * Example 1
+     * Create a simple change stream against an existing collection.
+     */
+    println("1. Initial document from the Change Stream:")
+
+    // Create the change stream observable.
+    var observable: ChangeStreamObservable[Document] = collection.watch()
+
+    // Create a observer
+    var observer = new LatchedObserver[ChangeStreamDocument[Document]]()
+    observable.subscribe(observer)
+
+    // Insert a test document into the collection and request a result
+    collection.insertOne(Document("{username: 'alice123', name: 'Alice'}")).execute()
+    observer.waitForThenCancel()
+
+    /*
+     * Example 2
+     * Create a change stream with 'lookup' option enabled.
+     * The test document will be returned with a full version of the updated document.
+     */
+    println("2. Document from the Change Stream, with lookup enabled:")
+
+    observable = collection.watch.fullDocument(FullDocument.UPDATE_LOOKUP)
+    observer = new LatchedObserver[ChangeStreamDocument[Document]]()
+    observable.subscribe(observer)
+
+    // Update the test document.
+    collection.updateOne(Document("{username: 'alice123'}"), Document("{$set : { email: 'alice@example.com'}}")).subscribeAndAwait()
+    observer.waitForThenCancel()
+
+    /*
+     * Example 3
+     * Create a change stream with 'lookup' option using a $match and ($redact or $project) stage.
+     */
+    println("3. Document from the Change Stream, with lookup enabled, matching `update` operations only: ")
+
+    // Insert some dummy data.
+    collection.insertMany(List(Document("{updateMe: 1}"), Document("{replaceMe: 1}"))).subscribeAndAwait()
+
+    // Create $match pipeline stage.
+    val pipeline = List(Aggregates.filter(Filters.or(Document("{'fullDocument.username': 'alice123'}"),
+      Filters.in("operationType", "update", "replace", "delete"))))
+
+    // Create the change stream cursor with $match.
+    observable = collection.watch(pipeline).fullDocument(FullDocument.UPDATE_LOOKUP)
+    observer = new LatchedObserver[ChangeStreamDocument[Document]](false, 3)
+    observable.subscribe(observer)
+
+    // Update the test document.
+    collection.updateOne(Filters.eq("updateMe", 1), Updates.set("updated", true)).subscribeAndAwait()
+    // Replace the test document.
+    collection.replaceOne(Filters.eq("replaceMe", 1), Document("{replaced: true}")).subscribeAndAwait()
+    // Delete the test document.
+    collection.deleteOne(Filters.eq("username", "alice123")).subscribeAndAwait()
+
+    observer.waitForThenCancel()
+
+    val results = observer.results()
+    println(
+      s"""
+         |Update operationType: ${results.head.getUpdateDescription}
+         |                      ${results.head}
+   """.stripMargin.trim)
+    println(s"Replace operationType: ${results(1)}")
+    println(s"Delete operationType: ${results(2)}")
+
+
+    /*
+     * Example 4
+     * Resume a change stream using a resume token.
+     */
+    println("4. Document from the Change Stream including a resume token:")
+
+    // Get the resume token from the last document we saw in the previous change stream cursor.
+    val resumeToken = results(2).getResumeToken
+    println(resumeToken)
+
+    // Pass the resume token to the resume after function to continue the change stream cursor.
+    observable = collection.watch.resumeAfter(resumeToken)
+    observer = new LatchedObserver[ChangeStreamDocument[Document]]
+    observable.subscribe(observer)
+
+    // Insert a test document.
+    collection.insertOne(Document("{test: 'd'}")).subscribeAndAwait()
+
+    // Block until the next result is printed
+    observer.waitForThenCancel()
+
+  }
+
+  // Implicit functions that execute the Observable and return the results
+  val waitDuration = Duration(5, "seconds")
+
+  implicit class ObservableExecutor[T](observable: Observable[T]) {
+    def execute(): Seq[T] = Await.result(observable, waitDuration)
+
+    def subscribeAndAwait(): Unit = {
+      val observer: LatchedObserver[T] = new LatchedObserver[T](false)
+      observable.subscribe(observer)
+      observer.await()
+    }
+  }
+
+  implicit class SingleObservableExecutor[T](observable: SingleObservable[T]) {
+    def execute(): T = Await.result(observable, waitDuration)
+  }
+
+  // end implicit functions
+
+  private class LatchedObserver[T](val printResults: Boolean = true, val minimumNumberOfResults: Int = 1) extends Observer[T] {
+    private val latch: CountDownLatch = new CountDownLatch(1)
+    private val resultsBuffer: mutable.ListBuffer[T] = new mutable.ListBuffer[T]
+    private var subscription: Option[Subscription] = None
+    private var error: Option[Throwable] = None
+
+    override def onSubscribe(s: Subscription): Unit = {
+      subscription = Some(s)
+      s.request(Integer.MAX_VALUE)
+    }
+
+    override def onNext(t: T): Unit = {
+      resultsBuffer.append(t)
+      if (printResults) println(t)
+      if (resultsBuffer.size >= minimumNumberOfResults) latch.countDown()
+    }
+
+    override def onError(t: Throwable): Unit = {
+      error = Some(t)
+      println(t.getMessage)
+      onComplete()
+    }
+
+    override def onComplete(): Unit = {
+      latch.countDown()
+    }
+
+    def results(): List[T] = resultsBuffer.toList
+
+    def await(): Unit = {
+      if (!latch.await(10, SECONDS)) throw new MongoTimeoutException("observable timed out")
+      if (error.isDefined) throw error.get
+    }
+
+    def waitForThenCancel(): Unit = {
+      if (minimumNumberOfResults > resultsBuffer.size) await()
+      subscription.foreach(_.unsubscribe())
+    }
+  }
+
+
+}

--- a/driver/src/it/scala/org/mongodb/scala/RequiresMongoDBISpec.scala
+++ b/driver/src/it/scala/org/mongodb/scala/RequiresMongoDBISpec.scala
@@ -25,6 +25,8 @@
 
 package org.mongodb.scala
 
+import com.mongodb.ConnectionString
+
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
@@ -32,9 +34,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.implicitConversions
 import scala.util.{Failure, Properties, Success, Try}
-
 import com.mongodb.connection.ServerVersion
-
 import org.mongodb.scala.bson.BsonString
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
@@ -74,6 +74,10 @@ trait RequiresMongoDBISpec extends FlatSpec with Matchers with ScalaFutures with
 
   def isMongoDBOnline(): Boolean = {
     Try(Await.result(MongoClient(mongoClientURI).listDatabaseNames(), WAIT_DURATION)).isSuccess
+  }
+
+  def hasSingleHost(): Boolean = {
+    new ConnectionString(mongoClientURI).getHosts.size() == 1
   }
 
   def checkMongoDB() {
@@ -123,7 +127,7 @@ trait RequiresMongoDBISpec extends FlatSpec with Matchers with ScalaFutures with
       case Some(version) =>
         val serverVersion = version.getValue.split("\\D+").map(_.toInt).padTo(3, 0).take(3).toList.asJava
         new ServerVersion(serverVersion.asInstanceOf[java.util.List[Integer]]).compareTo(
-          new ServerVersion(minServerVersion.asJava.asInstanceOf[java.util.List[Integer]])) > 0
+          new ServerVersion(minServerVersion.asJava.asInstanceOf[java.util.List[Integer]])) >= 0
       case None => false
     }
   }

--- a/driver/src/main/scala/org/mongodb/scala/AggregateObservable.scala
+++ b/driver/src/main/scala/org/mongodb/scala/AggregateObservable.scala
@@ -19,10 +19,9 @@ package org.mongodb.scala
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.Duration
-
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.async.client.AggregateIterable
-
+import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.internal.ObservableHelper._
 import org.mongodb.scala.model.Collation
 
@@ -57,6 +56,20 @@ case class AggregateObservable[TResult](private val wrapped: AggregateIterable[T
    */
   def maxTime(duration: Duration): AggregateObservable[TResult] = {
     wrapped.maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    this
+  }
+
+  /**
+   * Sets the maximum await execution time on the server for this operation.
+   *
+   * [[http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS/ Max Time]]
+   * @param duration the duration
+   * @return this
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def maxAwaitTime(duration: Duration): AggregateObservable[TResult] = {
+    wrapped.maxAwaitTime(duration.toMillis, TimeUnit.MILLISECONDS)
     this
   }
 
@@ -104,6 +117,32 @@ case class AggregateObservable[TResult](private val wrapped: AggregateIterable[T
    */
   def collation(collation: Collation): AggregateObservable[TResult] = {
     wrapped.collation(collation)
+    this
+  }
+
+  /**
+   * Sets the comment to the aggregation. A null value means no comment is set.
+   *
+   * @param comment the comment
+   * @return this
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def comment(comment: String): AggregateObservable[TResult] = {
+    wrapped.comment(comment)
+    this
+  }
+
+  /**
+   * Sets the hint for which index to use. A null value means no hint is set.
+   *
+   * @param hint the hint
+   * @return this
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def hint(hint: Bson): AggregateObservable[TResult] = {
+    wrapped.hint(hint)
     this
   }
 

--- a/driver/src/main/scala/org/mongodb/scala/ChangeStreamObservable.scala
+++ b/driver/src/main/scala/org/mongodb/scala/ChangeStreamObservable.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mongodb.scala
+
+import java.util.concurrent.TimeUnit
+
+import com.mongodb.async.client.{ChangeStreamIterable, MongoIterable}
+import org.mongodb.scala.internal.ObservableHelper._
+import org.mongodb.scala.model.Collation
+import org.mongodb.scala.model.changestream.{ChangeStreamDocument, FullDocument}
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Observable for change streams.
+ *
+ * '''Note:''' The [[org.mongodb.scala.model.changestream.ChangeStreamDocument]] class will not be applicable for all change stream outputs.
+ * If using custom pipelines that radically change the result, the the [[ChangeStreamObservable#withDocumentClass]] method should be used
+ * to provide an alternative document format.
+ *
+ * @param wrapped the underlying java ChangeStreamIterable
+ * @tparam TResult The type of the result.
+ * @since 2.2
+ * @note Requires MongoDB 3.6 or greater
+ */
+case class ChangeStreamObservable[TResult](private val wrapped: ChangeStreamIterable[TResult]) extends Observable[ChangeStreamDocument[TResult]] {
+
+  /**
+   * Sets the fullDocument value.
+   *
+   * @param fullDocument the fullDocument
+   * @return this
+   */
+  def fullDocument(fullDocument: FullDocument): ChangeStreamObservable[TResult] = {
+    wrapped.fullDocument(fullDocument)
+    this
+  }
+
+  /**
+   * Sets the logical starting point for the new change stream.
+   *
+   * @param resumeToken the resume token
+   * @return this
+   */
+  def resumeAfter(resumeToken: Document): ChangeStreamObservable[TResult] = {
+    wrapped.resumeAfter(resumeToken.underlying)
+    this
+  }
+
+  /**
+   * Sets the number of documents to return per batch.
+   *
+   * @param batchSize the batch size
+   * @return this
+   */
+  def batchSize(batchSize: Int): ChangeStreamObservable[TResult] = {
+    wrapped.batchSize(batchSize)
+    this
+  }
+
+  /**
+   * Sets the maximum await execution time on the server for this operation.
+   *
+   * [[http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS/ Max Time]]
+   * @param duration the duration
+   * @return this
+   */
+  def maxAwaitTime(duration: Duration): ChangeStreamObservable[TResult] = {
+    wrapped.maxAwaitTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    this
+  }
+
+  /**
+   * Sets the collation options
+   *
+   * A null value represents the server default.
+   *
+   * @param collation the collation options to use
+   * @return this
+   */
+  def collation(collation: Collation): ChangeStreamObservable[TResult] = {
+    wrapped.collation(collation)
+    this
+  }
+
+  /**
+   * Returns an `Observable` containing the results of the change stream based on the document class provided.
+   *
+   * @param clazz the class to use for the raw result.
+   * @tparam T the result type
+   * @return an Observable
+   */
+  def withDocumentClass[T](clazz: Class[T]): Observable[T] = observe(wrapped.withDocumentClass(clazz))
+
+  override def subscribe(observer: Observer[_ >: ChangeStreamDocument[TResult]]): Unit = observe(wrapped).subscribe(observer)
+}

--- a/driver/src/main/scala/org/mongodb/scala/ClientSessionOptions.scala
+++ b/driver/src/main/scala/org/mongodb/scala/ClientSessionOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2017 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-package org.mongodb.scala.connection
+package org.mongodb.scala
 
-import com.mongodb.connection.netty.{NettyStreamFactoryFactory => JNettyStreamFactoryFactory}
+import com.mongodb.{ClientSessionOptions => JClientSessionOptions}
 
 /**
- * A `StreamFactoryFactory` implementation for <a href='http://netty.io/'>Netty</a>-based streams.
+ * The options to apply to a `ClientSession`.
  *
- * @since 1.0
+ * @see ClientSession
+ * @since 2.2
  */
-object NettyStreamFactoryFactory {
-  def apply(): StreamFactoryFactory = JNettyStreamFactoryFactory.builder().build()
+object ClientSessionOptions {
 
   /**
-   * Create a builder for Netty-based streams
+   * Gets an instance of a builder
    *
-   * @return the builder
-   * @since 2.2
+   * @return a builder instance
    */
-  def builder(): NettyStreamFactoryFactoryBuilder = JNettyStreamFactoryFactory.builder()
+  def builder: JClientSessionOptions.Builder = JClientSessionOptions.builder
+
 }

--- a/driver/src/main/scala/org/mongodb/scala/ListDatabasesObservable.scala
+++ b/driver/src/main/scala/org/mongodb/scala/ListDatabasesObservable.scala
@@ -19,9 +19,8 @@ package org.mongodb.scala
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.Duration
-
 import com.mongodb.async.client.ListDatabasesIterable
-
+import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.internal.ObservableHelper._
 
 /**
@@ -42,6 +41,33 @@ case class ListDatabasesObservable[TResult](wrapped: ListDatabasesIterable[TResu
    */
   def maxTime(duration: Duration): ListDatabasesObservable[TResult] = {
     wrapped.maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    this
+  }
+
+  /**
+   * Sets the query filter to apply to the returned database names.
+   *
+   * @param filter the filter, which may be null.
+   * @return this
+   * @since 2.2
+   * @note Requires MongoDB 3.4.2 or greater
+   */
+  def filter(filter: Bson): ListDatabasesObservable[TResult] = {
+    wrapped.filter(filter)
+    this
+  }
+
+  /**
+   * Sets the nameOnly flag that indicates whether the command should return just the database names or return the database names and
+   * size information.
+   *
+   * @param nameOnly the nameOnly flag, which may be null
+   * @return this
+   * @since 2.2
+   * @note Requires MongoDB 3.4.3 or greater
+   */
+  def nameOnly(nameOnly: Boolean): ListDatabasesObservable[TResult] = {
+    wrapped.nameOnly(nameOnly)
     this
   }
 

--- a/driver/src/main/scala/org/mongodb/scala/MongoCollection.scala
+++ b/driver/src/main/scala/org/mongodb/scala/MongoCollection.scala
@@ -20,11 +20,9 @@ import java.util
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
-
 import org.bson.codecs.configuration.CodecRegistry
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.async.client.{MongoCollection => JMongoCollection}
-
 import org.mongodb.scala.bson.DefaultHelper.DefaultsTo
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.internal.ObservableHelper._
@@ -152,11 +150,47 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     observeLong(wrapped.count(filter, options, _: SingleResultCallback[java.lang.Long]))
 
   /**
+   * Counts the number of documents in the collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @return a Observable with a single element indicating the number of documents
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def count(clientSession: ClientSession): SingleObservable[Long] =
+    observeLong(wrapped.count(clientSession, _: SingleResultCallback[java.lang.Long]))
+
+  /**
+   * Counts the number of documents in the collection according to the given options.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter the query filter
+   * @return a Observable with a single element indicating the number of documents
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def count(clientSession: ClientSession, filter: Bson): SingleObservable[Long] =
+    observeLong(wrapped.count(clientSession, filter, _: SingleResultCallback[java.lang.Long]))
+
+  /**
+   * Counts the number of documents in the collection according to the given options.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  the query filter
+   * @param options the options describing the count
+   * @return a Observable with a single element indicating the number of documents
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def count(clientSession: ClientSession, filter: Bson, options: CountOptions): SingleObservable[Long] =
+    observeLong(wrapped.count(clientSession, filter, options, _: SingleResultCallback[java.lang.Long]))
+
+  /**
    * Gets the distinct values of the specified field name.
    *
    * [[http://docs.mongodb.org/manual/reference/command/distinct/ Distinct]]
    * @param fieldName the field name
-   * @tparam C       the target type of the iterable.
+   * @tparam C       the target type of the observable.
    * @return a Observable emitting the sequence of distinct values
    */
   def distinct[C](fieldName: String)(implicit ct: ClassTag[C]): DistinctObservable[C] =
@@ -168,18 +202,47 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    * [[http://docs.mongodb.org/manual/reference/command/distinct/ Distinct]]
    * @param fieldName the field name
    * @param filter  the query filter
-   * @tparam C       the target type of the iterable.
+   * @tparam C       the target type of the observable.
    * @return a Observable emitting the sequence of distinct values
    */
   def distinct[C](fieldName: String, filter: Bson)(implicit ct: ClassTag[C]): DistinctObservable[C] =
     DistinctObservable(wrapped.distinct(fieldName, filter, ct))
 
   /**
+   * Gets the distinct values of the specified field name.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/distinct/ Distinct]]
+   * @param clientSession the client session with which to associate this operation
+   * @param fieldName the field name
+   * @tparam C       the target type of the observable.
+   * @return a Observable emitting the sequence of distinct values
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def distinct[C](clientSession: ClientSession, fieldName: String)(implicit ct: ClassTag[C]): DistinctObservable[C] =
+    DistinctObservable(wrapped.distinct(clientSession, fieldName, ct))
+
+  /**
+   * Gets the distinct values of the specified field name.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/distinct/ Distinct]]
+   * @param clientSession the client session with which to associate this operation
+   * @param fieldName the field name
+   * @param filter  the query filter
+   * @tparam C       the target type of the observable.
+   * @return a Observable emitting the sequence of distinct values
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def distinct[C](clientSession: ClientSession, fieldName: String, filter: Bson)(implicit ct: ClassTag[C]): DistinctObservable[C] =
+    DistinctObservable(wrapped.distinct(clientSession, fieldName, filter, ct))
+
+  /**
    * Finds all documents in the collection.
    *
    * [[http://docs.mongodb.org/manual/tutorial/query-documents/ Find]]
    *
-   * @tparam C   the target document type of the iterable.
+   * @tparam C   the target document type of the observable.
    * @return the find Observable
    */
   def find[C]()(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): FindObservable[C] =
@@ -190,11 +253,39 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    *
    * [[http://docs.mongodb.org/manual/tutorial/query-documents/ Find]]
    * @param filter the query filter
-   * @tparam C    the target document type of the iterable.
+   * @tparam C    the target document type of the observable.
    * @return the find Observable
    */
   def find[C](filter: Bson)(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): FindObservable[C] =
     FindObservable(wrapped.find(filter, ct))
+
+  /**
+   * Finds all documents in the collection.
+   *
+   * [[http://docs.mongodb.org/manual/tutorial/query-documents/ Find]]
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @tparam C   the target document type of the observable.
+   * @return the find Observable
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def find[C](clientSession: ClientSession)(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): FindObservable[C] =
+    FindObservable(wrapped.find[C](clientSession, ct))
+
+  /**
+   * Finds all documents in the collection.
+   *
+   * [[http://docs.mongodb.org/manual/tutorial/query-documents/ Find]]
+   * @param clientSession the client session with which to associate this operation
+   * @param filter the query filter
+   * @tparam C    the target document type of the observable.
+   * @return the find Observable
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def find[C](clientSession: ClientSession, filter: Bson)(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): FindObservable[C] =
+    FindObservable(wrapped.find(clientSession, filter, ct))
 
   /**
    * Aggregates documents according to the specified aggregation pipeline.
@@ -207,16 +298,47 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     AggregateObservable(wrapped.aggregate[C](pipeline.asJava, ct))
 
   /**
+   * Aggregates documents according to the specified aggregation pipeline.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param pipeline the aggregate pipeline
+   * @return a Observable containing the result of the aggregation operation
+   *         [[http://docs.mongodb.org/manual/aggregation/ Aggregation]]
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def aggregate[C](clientSession: ClientSession, pipeline: Seq[Bson])(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): AggregateObservable[C] =
+    AggregateObservable(wrapped.aggregate[C](clientSession, pipeline.asJava, ct))
+
+  /**
    * Aggregates documents according to the specified map-reduce function.
    *
    * @param mapFunction    A JavaScript function that associates or "maps" a value with a key and emits the key and value pair.
    * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
-   * @tparam C            the target document type of the iterable.
+   * @tparam C            the target document type of the observable.
    * @return a Observable containing the result of the map-reduce operation
    *         [[http://docs.mongodb.org/manual/reference/command/mapReduce/ map-reduce]]
    */
   def mapReduce[C](mapFunction: String, reduceFunction: String)(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): MapReduceObservable[C] =
     MapReduceObservable(wrapped.mapReduce(mapFunction, reduceFunction, ct))
+
+  /**
+   * Aggregates documents according to the specified map-reduce function.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param mapFunction    A JavaScript function that associates or "maps" a value with a key and emits the key and value pair.
+   * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
+   * @tparam C            the target document type of the observable.
+   * @return a Observable containing the result of the map-reduce operation
+   *         [[http://docs.mongodb.org/manual/reference/command/mapReduce/ map-reduce]]
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def mapReduce[C](clientSession: ClientSession, mapFunction: String, reduceFunction: String)(
+    implicit
+    e: C DefaultsTo TResult, ct: ClassTag[C]
+  ): MapReduceObservable[C] =
+    MapReduceObservable(wrapped.mapReduce(clientSession, mapFunction, reduceFunction, ct))
 
   /**
    * Executes a mix of inserts, updates, replaces, and deletes.
@@ -225,7 +347,10 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    * @return a Observable with a single element the BulkWriteResult
    */
   def bulkWrite(requests: Seq[_ <: WriteModel[_ <: TResult]]): SingleObservable[BulkWriteResult] =
-    observe(wrapped.bulkWrite(requests.asJava.asInstanceOf[util.List[_ <: WriteModel[_ <: TResult]]], _: SingleResultCallback[BulkWriteResult]))
+    observe(wrapped.bulkWrite(
+      requests.asJava.asInstanceOf[util.List[_ <: WriteModel[_ <: TResult]]],
+      _: SingleResultCallback[BulkWriteResult]
+    ))
 
   /**
    * Executes a mix of inserts, updates, replaces, and deletes.
@@ -236,6 +361,40 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    */
   def bulkWrite(requests: Seq[_ <: WriteModel[_ <: TResult]], options: BulkWriteOptions): SingleObservable[BulkWriteResult] =
     observe(wrapped.bulkWrite(
+      requests.asJava.asInstanceOf[util.List[_ <: WriteModel[_ <: TResult]]],
+      options,
+      _: SingleResultCallback[BulkWriteResult]
+    ))
+
+  /**
+   * Executes a mix of inserts, updates, replaces, and deletes.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param requests the writes to execute
+   * @return a Observable with a single element the BulkWriteResult
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def bulkWrite(clientSession: ClientSession, requests: Seq[_ <: WriteModel[_ <: TResult]]): SingleObservable[BulkWriteResult] =
+    observe(wrapped.bulkWrite(
+      clientSession,
+      requests.asJava.asInstanceOf[util.List[_ <: WriteModel[_ <: TResult]]],
+      _: SingleResultCallback[BulkWriteResult]
+    ))
+
+  /**
+   * Executes a mix of inserts, updates, replaces, and deletes.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param requests the writes to execute
+   * @param options  the options to apply to the bulk write operation
+   * @return a Observable with a single element the BulkWriteResult
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def bulkWrite(clientSession: ClientSession, requests: Seq[_ <: WriteModel[_ <: TResult]], options: BulkWriteOptions): SingleObservable[BulkWriteResult] =
+    observe(wrapped.bulkWrite(
+      clientSession,
       requests.asJava.asInstanceOf[util.List[_ <: WriteModel[_ <: TResult]]],
       options,
       _: SingleResultCallback[BulkWriteResult]
@@ -263,6 +422,33 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     observeCompleted(wrapped.insertOne(document, options, _: SingleResultCallback[Void]))
 
   /**
+   * Inserts the provided document. If the document is missing an identifier, the driver should generate one.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param document the document to insert
+   * @return a Observable with a single element indicating when the operation has completed or with either a
+   *         com.mongodb.DuplicateKeyException or com.mongodb.MongoException
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def insertOne(clientSession: ClientSession, document: TResult): SingleObservable[Completed] =
+    observeCompleted(wrapped.insertOne(clientSession, document, _: SingleResultCallback[Void]))
+
+  /**
+   * Inserts the provided document. If the document is missing an identifier, the driver should generate one.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param document the document to insert
+   * @param options  the options to apply to the operation
+   * @return a Observable with a single element indicating when the operation has completed or with either a
+   *         com.mongodb.DuplicateKeyException or com.mongodb.MongoException
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def insertOne(clientSession: ClientSession, document: TResult, options: InsertOneOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.insertOne(clientSession, document, options, _: SingleResultCallback[Void]))
+
+  /**
    * Inserts a batch of documents. The preferred way to perform bulk inserts is to use the BulkWrite API. However, when talking with a
    * server &lt; 2.6, using this method will be faster due to constraints in the bulk API related to error handling.
    *
@@ -286,6 +472,33 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     observeCompleted(wrapped.insertMany(documents.asJava, options, _: SingleResultCallback[Void]))
 
   /**
+   * Inserts a batch of documents. The preferred way to perform bulk inserts is to use the BulkWrite API.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param documents the documents to insert
+   * @return a Observable with a single element indicating when the operation has completed or with either a
+   *         com.mongodb.DuplicateKeyException or com.mongodb.MongoException
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def insertMany(clientSession: ClientSession, documents: Seq[_ <: TResult]): SingleObservable[Completed] =
+    observeCompleted(wrapped.insertMany(clientSession, documents.asJava, _: SingleResultCallback[Void]))
+
+  /**
+   * Inserts a batch of documents. The preferred way to perform bulk inserts is to use the BulkWrite API.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param documents the documents to insert
+   * @param options   the options to apply to the operation
+   * @return a Observable with a single element indicating when the operation has completed or with either a
+   *         com.mongodb.DuplicateKeyException or com.mongodb.MongoException
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def insertMany(clientSession: ClientSession, documents: Seq[_ <: TResult], options: InsertManyOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.insertMany(clientSession, documents.asJava, options, _: SingleResultCallback[Void]))
+
+  /**
    * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
    * modified.
    *
@@ -307,6 +520,33 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     observe(wrapped.deleteOne(filter, options, _: SingleResultCallback[DeleteResult]))
 
   /**
+   * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
+   * modified.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter the query filter to apply the the delete operation
+   * @return a Observable with a single element the DeleteResult or with an com.mongodb.MongoException
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def deleteOne(clientSession: ClientSession, filter: Bson): SingleObservable[DeleteResult] =
+    observe(wrapped.deleteOne(clientSession, filter, _: SingleResultCallback[DeleteResult]))
+
+  /**
+   * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
+   * modified.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter the query filter to apply the the delete operation
+   * @param options the options to apply to the delete operation
+   * @return a Observable with a single element the DeleteResult or with an com.mongodb.MongoException
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def deleteOne(clientSession: ClientSession, filter: Bson, options: DeleteOptions): SingleObservable[DeleteResult] =
+    observe(wrapped.deleteOne(clientSession, filter, options, _: SingleResultCallback[DeleteResult]))
+
+  /**
    * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
    *
    * @param filter the query filter to apply the the delete operation
@@ -324,6 +564,31 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    */
   def deleteMany(filter: Bson, options: DeleteOptions): SingleObservable[DeleteResult] =
     observe(wrapped.deleteMany(filter, options, _: SingleResultCallback[DeleteResult]))
+
+  /**
+   * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter the query filter to apply the the delete operation
+   * @return a Observable with a single element the DeleteResult or with an com.mongodb.MongoException
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def deleteMany(clientSession: ClientSession, filter: Bson): SingleObservable[DeleteResult] =
+    observe(wrapped.deleteMany(clientSession, filter, _: SingleResultCallback[DeleteResult]))
+
+  /**
+   * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter the query filter to apply the the delete operation
+   * @param options the options to apply to the delete operation
+   * @return a Observable with a single element the DeleteResult or with an com.mongodb.MongoException
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def deleteMany(clientSession: ClientSession, filter: Bson, options: DeleteOptions): SingleObservable[DeleteResult] =
+    observe(wrapped.deleteMany(clientSession, filter, options, _: SingleResultCallback[DeleteResult]))
 
   /**
    * Replace a document in the collection according to the specified arguments.
@@ -349,14 +614,43 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     observe(wrapped.replaceOne(filter, replacement, options, _: SingleResultCallback[UpdateResult]))
 
   /**
+   * Replace a document in the collection according to the specified arguments.
+   *
+   * [[http://docs.mongodb.org/manual/tutorial/modify-documents/#replace-the-document Replace]]
+   * @param clientSession the client session with which to associate this operation
+   * @param filter      the query filter to apply the the replace operation
+   * @param replacement the replacement document
+   * @return a Observable with a single element the UpdateResult
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def replaceOne(clientSession: ClientSession, filter: Bson, replacement: TResult): SingleObservable[UpdateResult] =
+    observe(wrapped.replaceOne(clientSession, filter, replacement, _: SingleResultCallback[UpdateResult]))
+
+  /**
+   * Replace a document in the collection according to the specified arguments.
+   *
+   * [[http://docs.mongodb.org/manual/tutorial/modify-documents/#replace-the-document Replace]]
+   * @param clientSession the client session with which to associate this operation
+   * @param filter      the query filter to apply the the replace operation
+   * @param replacement the replacement document
+   * @param options     the options to apply to the replace operation
+   * @return a Observable with a single element the UpdateResult
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def replaceOne(clientSession: ClientSession, filter: Bson, replacement: TResult, options: UpdateOptions): SingleObservable[UpdateResult] =
+    observe(wrapped.replaceOne(clientSession, filter, replacement, options, _: SingleResultCallback[UpdateResult]))
+
+  /**
    * Update a single document in the collection according to the specified arguments.
    *
    * [[http://docs.mongodb.org/manual/tutorial/modify-documents/ Updates]]
    * [[http://docs.mongodb.org/manual/reference/operator/update/ Update Operators]]
-   * @param filter a document describing the query filter, which may not be null. This can be of any type for which a { @code Codec} is
-   *               registered
-   * @param update a document describing the update, which may not be null. The update to apply must include only update operators. This
-   *               can be of any type for which a { @code Codec} is registered
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
    * @return a Observable with a single element the UpdateResult
    */
   def updateOne(filter: Bson, update: Bson): SingleObservable[UpdateResult] =
@@ -367,10 +661,10 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    *
    * [[http://docs.mongodb.org/manual/tutorial/modify-documents/ Updates]]
    * [[http://docs.mongodb.org/manual/reference/operator/update/ Update Operators]]
-   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a { @code Codec} is
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
    *                registered
    * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
-   *                can be of any type for which a { @code Codec} is registered
+   *                can be of any type for which a `Codec` is registered
    * @param options the options to apply to the update operation
    * @return a Observable with a single element the UpdateResult
    */
@@ -382,10 +676,45 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    *
    * [[http://docs.mongodb.org/manual/tutorial/modify-documents/ Updates]]
    * [[http://docs.mongodb.org/manual/reference/operator/update/ Update Operators]]
-   * @param filter a document describing the query filter, which may not be null. This can be of any type for which a { @code Codec} is
-   *               registered
-   * @param update a document describing the update, which may not be null. The update to apply must include only update operators. This
-   *               can be of any type for which a { @code Codec} is registered
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
+   * @return a Observable with a single element the UpdateResult
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def updateOne(clientSession: ClientSession, filter: Bson, update: Bson): SingleObservable[UpdateResult] =
+    observe(wrapped.updateOne(clientSession, filter, update, _: SingleResultCallback[UpdateResult]))
+
+  /**
+   * Update a single document in the collection according to the specified arguments.
+   *
+   * [[http://docs.mongodb.org/manual/tutorial/modify-documents/ Updates]]
+   * [[http://docs.mongodb.org/manual/reference/operator/update/ Update Operators]]
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
+   * @param options the options to apply to the update operation
+   * @return a Observable with a single element the UpdateResult
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def updateOne(clientSession: ClientSession, filter: Bson, update: Bson, options: UpdateOptions): SingleObservable[UpdateResult] =
+    observe(wrapped.updateOne(clientSession, filter, update, options, _: SingleResultCallback[UpdateResult]))
+
+  /**
+   * Update a single document in the collection according to the specified arguments.
+   *
+   * [[http://docs.mongodb.org/manual/tutorial/modify-documents/ Updates]]
+   * [[http://docs.mongodb.org/manual/reference/operator/update/ Update Operators]]
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
    * @return a Observable with a single element the UpdateResult
    */
   def updateMany(filter: Bson, update: Bson): SingleObservable[UpdateResult] =
@@ -396,10 +725,10 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    *
    * [[http://docs.mongodb.org/manual/tutorial/modify-documents/ Updates]]
    * [[http://docs.mongodb.org/manual/reference/operator/update/ Update Operators]]
-   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a { @code Codec} is
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
    *                registered
    * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
-   *                can be of any type for which a { @code Codec} is registered
+   *                can be of any type for which a `Codec` is registered
    * @param options the options to apply to the update operation
    * @return a Observable with a single element the UpdateResult
    */
@@ -407,9 +736,44 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     observe(wrapped.updateMany(filter, update, options, _: SingleResultCallback[UpdateResult]))
 
   /**
+   * Update a single document in the collection according to the specified arguments.
+   *
+   * [[http://docs.mongodb.org/manual/tutorial/modify-documents/ Updates]]
+   * [[http://docs.mongodb.org/manual/reference/operator/update/ Update Operators]]
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
+   * @return a Observable with a single element the UpdateResult
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def updateMany(clientSession: ClientSession, filter: Bson, update: Bson): SingleObservable[UpdateResult] =
+    observe(wrapped.updateMany(clientSession, filter, update, _: SingleResultCallback[UpdateResult]))
+
+  /**
+   * Update a single document in the collection according to the specified arguments.
+   *
+   * [[http://docs.mongodb.org/manual/tutorial/modify-documents/ Updates]]
+   * [[http://docs.mongodb.org/manual/reference/operator/update/ Update Operators]]
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
+   * @param options the options to apply to the update operation
+   * @return a Observable with a single element the UpdateResult
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def updateMany(clientSession: ClientSession, filter: Bson, update: Bson, options: UpdateOptions): SingleObservable[UpdateResult] =
+    observe(wrapped.updateMany(clientSession, filter, update, options, _: SingleResultCallback[UpdateResult]))
+
+  /**
    * Atomically find a document and remove it.
    *
-   * @param filter the query filter to find the document with
+   * @param filter  the query filter to find the document with
    * @return a Observable with a single element the document that was removed.  If no documents matched the query filter, then null will be
    *         returned
    */
@@ -427,11 +791,38 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     observe(wrapped.findOneAndDelete(filter, options, _: SingleResultCallback[TResult]))
 
   /**
+   * Atomically find a document and remove it.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  the query filter to find the document with
+   * @return a Observable with a single element the document that was removed.  If no documents matched the query filter, then null will be
+   *         returned
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def findOneAndDelete(clientSession: ClientSession, filter: Bson): SingleObservable[TResult] =
+    observe(wrapped.findOneAndDelete(clientSession, filter, _: SingleResultCallback[TResult]))
+
+  /**
+   * Atomically find a document and remove it.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  the query filter to find the document with
+   * @param options the options to apply to the operation
+   * @return a Observable with a single element the document that was removed.  If no documents matched the query filter, then null will be
+   *         returned
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def findOneAndDelete(clientSession: ClientSession, filter: Bson, options: FindOneAndDeleteOptions): SingleObservable[TResult] =
+    observe(wrapped.findOneAndDelete(clientSession, filter, options, _: SingleResultCallback[TResult]))
+
+  /**
    * Atomically find a document and replace it.
    *
    * @param filter      the query filter to apply the the replace operation
    * @param replacement the replacement document
-   * @return a Observable with a single element the document that was replaced.  Depending on the value of the { @code returnOriginal}
+   * @return a Observable with a single element the document that was replaced.  Depending on the value of the `returnOriginal`
    *         property, this will either be the document as it was before the update or as it is after the update.  If no documents matched the
    *         query filter, then null will be returned
    */
@@ -444,7 +835,7 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    * @param filter      the query filter to apply the the replace operation
    * @param replacement the replacement document
    * @param options     the options to apply to the operation
-   * @return a Observable with a single element the document that was replaced.  Depending on the value of the { @code returnOriginal}
+   * @return a Observable with a single element the document that was replaced.  Depending on the value of the `returnOriginal`
    *         property, this will either be the document as it was before the update or as it is after the update.  If no documents matched the
    *         query filter, then null will be returned
    */
@@ -452,13 +843,45 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
     observe(wrapped.findOneAndReplace(filter, replacement, options, _: SingleResultCallback[TResult]))
 
   /**
+   * Atomically find a document and replace it.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter      the query filter to apply the the replace operation
+   * @param replacement the replacement document
+   * @return a Observable with a single element the document that was replaced.  Depending on the value of the `returnOriginal`
+   *         property, this will either be the document as it was before the update or as it is after the update.  If no documents matched the
+   *         query filter, then null will be returned
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def findOneAndReplace(clientSession: ClientSession, filter: Bson, replacement: TResult): SingleObservable[TResult] =
+    observe(wrapped.findOneAndReplace(clientSession, filter, replacement, _: SingleResultCallback[TResult]))
+
+  /**
+   * Atomically find a document and replace it.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter      the query filter to apply the the replace operation
+   * @param replacement the replacement document
+   * @param options     the options to apply to the operation
+   * @return a Observable with a single element the document that was replaced.  Depending on the value of the `returnOriginal`
+   *         property, this will either be the document as it was before the update or as it is after the update.  If no documents matched the
+   *         query filter, then null will be returned
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def findOneAndReplace(clientSession: ClientSession, filter: Bson, replacement: TResult, options: FindOneAndReplaceOptions): SingleObservable[TResult] =
+    observe(wrapped.findOneAndReplace(clientSession, filter, replacement, options, _: SingleResultCallback[TResult]))
+
+  /**
    * Atomically find a document and update it.
    *
-   * @param filter a document describing the query filter, which may not be null. This can be of any type for which a { @code Codec} is
-   *               registered
-   * @param update a document describing the update, which may not be null. The update to apply must include only update operators. This
-   *               can be of any type for which a { @code Codec} is registered
-   * @return a Observable with a single element the document that was updated before the update was applied.  If no documents matched the
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
+   * @return a Observable with a single element the document that was updated.  Depending on the value of the `returnOriginal`
+   *         property, this will either be the document as it was before the update or as it is after the update.  If no documents matched the
    *         query filter, then null will be returned
    */
   def findOneAndUpdate(filter: Bson, update: Bson): SingleObservable[TResult] =
@@ -467,17 +890,52 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
   /**
    * Atomically find a document and update it.
    *
-   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a { @code Codec} is
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
    *                registered
    * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
-   *                can be of any type for which a { @code Codec} is registered
+   *                can be of any type for which a `Codec` is registered
    * @param options the options to apply to the operation
-   * @return a Observable with a single element the document that was updated.  Depending on the value of the { @code returnOriginal}
+   * @return a Observable with a single element the document that was updated.  Depending on the value of the `returnOriginal`
    *         property, this will either be the document as it was before the update or as it is after the update.  If no documents matched the
    *         query filter, then null will be returned
    */
   def findOneAndUpdate(filter: Bson, update: Bson, options: FindOneAndUpdateOptions): SingleObservable[TResult] =
     observe(wrapped.findOneAndUpdate(filter, update, options, _: SingleResultCallback[TResult]))
+
+  /**
+   * Atomically find a document and update it.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
+   * @return a Observable with a single element the document that was updated.  Depending on the value of the `returnOriginal`
+   *         property, this will either be the document as it was before the update or as it is after the update.  If no documents matched the
+   *         query filter, then null will be returned
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def findOneAndUpdate(clientSession: ClientSession, filter: Bson, update: Bson): SingleObservable[TResult] =
+    observe(wrapped.findOneAndUpdate(clientSession, filter, update, _: SingleResultCallback[TResult]))
+
+  /**
+   * Atomically find a document and update it.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
+   *                can be of any type for which a `Codec` is registered
+   * @param options the options to apply to the operation
+   * @return a Observable with a single element the document that was updated.  Depending on the value of the `returnOriginal`
+   *         property, this will either be the document as it was before the update or as it is after the update.  If no documents matched the
+   *         query filter, then null will be returned
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def findOneAndUpdate(clientSession: ClientSession, filter: Bson, update: Bson, options: FindOneAndUpdateOptions): SingleObservable[TResult] =
+    observe(wrapped.findOneAndUpdate(clientSession, filter, update, options, _: SingleResultCallback[TResult]))
 
   /**
    * Drops this collection from the Database.
@@ -488,18 +946,28 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
   def drop(): SingleObservable[Completed] = observeCompleted(wrapped.drop(_: SingleResultCallback[Void]))
 
   /**
-   * Create an Index
+   * Drops this collection from the Database.
    *
-   * @param key an object describing the index key(s), which may not be null. This can be of any type for which a { @code Codec} is
-   *            registered
+   * @param clientSession the client session with which to associate this operation
    * @return a Observable with a single element indicating when the operation has completed
-   *         [[http://docs.mongodb.org/manual/reference/method/db.collection.ensureIndex Ensure Index]]
+   *         [[http://docs.mongodb.org/manual/reference/command/drop/ Drop Collection]]
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
    */
-  def createIndex(key: Bson): SingleObservable[String] = observe(wrapped.createIndex(key, _: SingleResultCallback[String]))
+  def drop(clientSession: ClientSession): SingleObservable[Completed] = observeCompleted(wrapped.drop(clientSession, _: SingleResultCallback[Void]))
 
   /**
    * [[http://docs.mongodb.org/manual/reference/command/createIndexes Create Index]]
-   * @param key     an object describing the index key(s), which may not be null. This can be of any type for which a { @code Codec} is
+   * @param key     an object describing the index key(s), which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @return a Observable with a single element indicating when the operation has completed
+   */
+  def createIndex(key: Bson): SingleObservable[String] =
+    observe(wrapped.createIndex(key, _: SingleResultCallback[String]))
+
+  /**
+   * [[http://docs.mongodb.org/manual/reference/command/createIndexes Create Index]]
+   * @param key     an object describing the index key(s), which may not be null. This can be of any type for which a `Codec` is
    *                registered
    * @param options the options for the index
    * @return a Observable with a single element indicating when the operation has completed
@@ -509,21 +977,100 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
 
   /**
    * [[http://docs.mongodb.org/manual/reference/command/createIndexes Create Index]]
-   * @param models the list of indexes to create
+   * @param clientSession the client session with which to associate this operation
+   * @param key     an object describing the index key(s), which may not be null. This can be of any type for which a `Codec` is
+   *                registered
    * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def createIndex(clientSession: ClientSession, key: Bson): SingleObservable[String] =
+    observe(wrapped.createIndex(clientSession, key, _: SingleResultCallback[String]))
+
+  /**
+   * [[http://docs.mongodb.org/manual/reference/command/createIndexes Create Index]]
+   * @param clientSession the client session with which to associate this operation
+   * @param key     an object describing the index key(s), which may not be null. This can be of any type for which a `Codec` is
+   *                registered
+   * @param options the options for the index
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def createIndex(clientSession: ClientSession, key: Bson, options: IndexOptions): SingleObservable[String] =
+    observe(wrapped.createIndex(clientSession, key, options, _: SingleResultCallback[String]))
+
+  /**
+   * Create multiple indexes.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/createIndexes Create Index]]
+   * @param models the list of indexes to create
+   * @return a Observable with the names of the indexes
    */
   def createIndexes(models: Seq[IndexModel]): SingleObservable[String] =
     observeAndFlatten(wrapped.createIndexes(models.asJava, _: SingleResultCallback[util.List[String]]))
 
   /**
+   * Create multiple indexes.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/createIndexes Create Index]]
+   * @param models the list of indexes to create
+   * @param createIndexOptions options to use when creating indexes
+   * @return a Observable with the names of the indexes
+   * @since 2.2
+   */
+  def createIndexes(models: Seq[IndexModel], createIndexOptions: CreateIndexOptions): SingleObservable[String] =
+    observeAndFlatten(wrapped.createIndexes(models.asJava, createIndexOptions, _: SingleResultCallback[util.List[String]]))
+
+  /**
+   * Create multiple indexes.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/createIndexes Create Index]]
+   * @param clientSession the client session with which to associate this operation
+   * @param models the list of indexes to create
+   * @return a Observable with the names of the indexes
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def createIndexes(clientSession: ClientSession, models: Seq[IndexModel]): SingleObservable[String] =
+    observeAndFlatten(wrapped.createIndexes(clientSession, models.asJava, _: SingleResultCallback[util.List[String]]))
+
+  /**
+   * Create multiple indexes.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/createIndexes Create Index]]
+   * @param clientSession the client session with which to associate this operation
+   * @param models the list of indexes to create
+   * @param createIndexOptions options to use when creating indexes
+   * @return a Observable with the names of the indexes
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def createIndexes(clientSession: ClientSession, models: Seq[IndexModel], createIndexOptions: CreateIndexOptions): SingleObservable[String] =
+    observeAndFlatten(wrapped.createIndexes(clientSession, models.asJava, createIndexOptions, _: SingleResultCallback[util.List[String]]))
+
+  /**
    * Get all the indexes in this collection.
    *
    * [[http://docs.mongodb.org/manual/reference/command/listIndexes/ listIndexes]]
-   * @tparam C   the target document type of the iterable.
+   * @tparam C   the target document type of the observable.
    * @return the fluent list indexes interface
    */
   def listIndexes[C]()(implicit e: C DefaultsTo Document, ct: ClassTag[C]): ListIndexesObservable[C] =
     ListIndexesObservable(wrapped.listIndexes(ct))
+
+  /**
+   * Get all the indexes in this collection.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/listIndexes/ listIndexes]]
+   * @param clientSession the client session with which to associate this operation
+   * @tparam C   the target document type of the observable.
+   * @return the fluent list indexes interface
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def listIndexes[C](clientSession: ClientSession)(implicit e: C DefaultsTo Document, ct: ClassTag[C]): ListIndexesObservable[C] =
+    ListIndexesObservable(wrapped.listIndexes(clientSession, ct))
 
   /**
    * Drops the given index.
@@ -535,6 +1082,18 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
   def dropIndex(indexName: String): SingleObservable[Completed] = observeCompleted(wrapped.dropIndex(indexName, _: SingleResultCallback[Void]))
 
   /**
+   * Drops the given index.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/dropIndexes/ Drop Indexes]]
+   * @param indexName the name of the index to remove
+   * @param dropIndexOptions options to use when dropping indexes
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   */
+  def dropIndex(indexName: String, dropIndexOptions: DropIndexOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndex(indexName, dropIndexOptions, _: SingleResultCallback[Void]))
+
+  /**
    * Drops the index given the keys used to create it.
    *
    * @param keys the keys of the index to remove
@@ -543,18 +1102,118 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
   def dropIndex(keys: Bson): SingleObservable[Completed] = observeCompleted(wrapped.dropIndex(keys, _: SingleResultCallback[Void]))
 
   /**
+   * Drops the index given the keys used to create it.
+   *
+   * @param keys the keys of the index to remove
+   * @param dropIndexOptions options to use when dropping indexes
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   */
+  def dropIndex(keys: Bson, dropIndexOptions: DropIndexOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndex(keys, dropIndexOptions, _: SingleResultCallback[Void]))
+
+  /**
+   * Drops the given index.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/dropIndexes/ Drop Indexes]]
+   * @param clientSession the client session with which to associate this operation
+   * @param indexName the name of the index to remove
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def dropIndex(clientSession: ClientSession, indexName: String): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndex(clientSession, indexName, _: SingleResultCallback[Void]))
+
+  /**
+   * Drops the given index.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/dropIndexes/ Drop Indexes]]
+   * @param clientSession the client session with which to associate this operation
+   * @param indexName the name of the index to remove
+   * @param dropIndexOptions options to use when dropping indexes
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def dropIndex(clientSession: ClientSession, indexName: String, dropIndexOptions: DropIndexOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndex(clientSession, indexName, dropIndexOptions, _: SingleResultCallback[Void]))
+
+  /**
+   * Drops the index given the keys used to create it.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param keys the keys of the index to remove
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def dropIndex(clientSession: ClientSession, keys: Bson): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndex(clientSession, keys, _: SingleResultCallback[Void]))
+
+  /**
+   * Drops the index given the keys used to create it.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param keys the keys of the index to remove
+   * @param dropIndexOptions options to use when dropping indexes
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def dropIndex(clientSession: ClientSession, keys: Bson, dropIndexOptions: DropIndexOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndex(clientSession, keys, dropIndexOptions, _: SingleResultCallback[Void]))
+
+  /**
    * Drop all the indexes on this collection, except for the default on _id.
    *
    * [[http://docs.mongodb.org/manual/reference/command/dropIndexes/ Drop Indexes]]
    * @return a Observable with a single element indicating when the operation has completed
    */
-  def dropIndexes(): SingleObservable[Completed] = observeCompleted(wrapped.dropIndexes(_: SingleResultCallback[Void]))
+  def dropIndexes(): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndexes(_: SingleResultCallback[Void]))
+
+  /**
+   * Drop all the indexes on this collection, except for the default on _id.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/dropIndexes/ Drop Indexes]]
+   * @param dropIndexOptions options to use when dropping indexes
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   */
+  def dropIndexes(dropIndexOptions: DropIndexOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndexes(dropIndexOptions, _: SingleResultCallback[Void]))
+
+  /**
+   * Drop all the indexes on this collection, except for the default on _id.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/dropIndexes/ Drop Indexes]]
+   * @param clientSession the client session with which to associate this operation
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def dropIndexes(clientSession: ClientSession): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndexes(clientSession, _: SingleResultCallback[Void]))
+
+  /**
+   * Drop all the indexes on this collection, except for the default on _id.
+   *
+   * [[http://docs.mongodb.org/manual/reference/command/dropIndexes/ Drop Indexes]]
+   * @param clientSession the client session with which to associate this operation
+   * @param dropIndexOptions options to use when dropping indexes
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def dropIndexes(clientSession: ClientSession, dropIndexOptions: DropIndexOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.dropIndexes(clientSession, dropIndexOptions, _: SingleResultCallback[Void]))
 
   /**
    * Rename the collection with oldCollectionName to the newCollectionName.
    *
    * [[http://docs.mongodb.org/manual/reference/commands/renameCollection Rename collection]]
-   * @param newCollectionNamespace the namespace the collection will be renamed to
+   * @param newCollectionNamespace the name the collection will be renamed to
    * @return a Observable with a single element indicating when the operation has completed
    */
   def renameCollection(newCollectionNamespace: MongoNamespace): SingleObservable[Completed] =
@@ -570,6 +1229,81 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    */
   def renameCollection(newCollectionNamespace: MongoNamespace, options: RenameCollectionOptions): SingleObservable[Completed] =
     observeCompleted(wrapped.renameCollection(newCollectionNamespace, options, _: SingleResultCallback[Void]))
+
+  /**
+   * Rename the collection with oldCollectionName to the newCollectionName.
+   *
+   * [[http://docs.mongodb.org/manual/reference/commands/renameCollection Rename collection]]
+   * @param clientSession the client session with which to associate this operation
+   * @param newCollectionNamespace the name the collection will be renamed to
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def renameCollection(clientSession: ClientSession, newCollectionNamespace: MongoNamespace): SingleObservable[Completed] =
+    observeCompleted(wrapped.renameCollection(clientSession, newCollectionNamespace, _: SingleResultCallback[Void]))
+
+  /**
+   * Rename the collection with oldCollectionName to the newCollectionName.
+   *
+   * [[http://docs.mongodb.org/manual/reference/commands/renameCollection Rename collection]]
+   * @param clientSession the client session with which to associate this operation
+   * @param newCollectionNamespace the name the collection will be renamed to
+   * @param options                the options for renaming a collection
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def renameCollection(clientSession: ClientSession, newCollectionNamespace: MongoNamespace,
+                       options: RenameCollectionOptions): SingleObservable[Completed] =
+    observeCompleted(wrapped.renameCollection(clientSession, newCollectionNamespace, options, _: SingleResultCallback[Void]))
+
+  /**
+   * Creates a change stream for this collection.
+   *
+   * @tparam C   the target document type of the observable.
+   * @return the change stream observable
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def watch[C]()(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): ChangeStreamObservable[C] = ChangeStreamObservable(wrapped.watch(ct))
+
+  /**
+   * Creates a change stream for this collection.
+   *
+   * @param pipeline the aggregation pipeline to apply to the change stream
+   * @tparam C   the target document type of the observable.
+   * @return the change stream observable
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def watch[C](pipeline: Seq[Bson])(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): ChangeStreamObservable[C] =
+    ChangeStreamObservable(wrapped.watch(pipeline.asJava, ct))
+
+  /**
+   * Creates a change stream for this collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @tparam C   the target document type of the observable.
+   * @return the change stream observable
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def watch[C](clientSession: ClientSession)(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): ChangeStreamObservable[C] =
+    ChangeStreamObservable(wrapped.watch(clientSession, ct))
+
+  /**
+   * Creates a change stream for this collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param pipeline the aggregation pipeline to apply to the change stream
+   * @tparam C   the target document type of the observable.
+   * @return the change stream observable
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def watch[C](clientSession: ClientSession, pipeline: Seq[Bson])(implicit e: C DefaultsTo TResult, ct: ClassTag[C]): ChangeStreamObservable[C] =
+    ChangeStreamObservable(wrapped.watch(clientSession, pipeline.asJava, ct))
 
 }
 

--- a/driver/src/main/scala/org/mongodb/scala/MongoCompressor.scala
+++ b/driver/src/main/scala/org/mongodb/scala/MongoCompressor.scala
@@ -21,7 +21,7 @@ import com.mongodb.{MongoCompressor => JMongoCompressor}
 /**
  * Metadata describing a compressor to use for sending and receiving messages to a MongoDB server.
  *
- * @since 3.6
+ * @since 2.2
  * @note Requires MongoDB 3.4 or greater
  */
 object MongoCompressor {
@@ -37,6 +37,7 @@ object MongoCompressor {
    * Create an instance for zlib compression.
    *
    * @return A compressor based on the zlib compression algorithm
+   * @note Requires MongoDB 3.6 or greater
    */
   def createZlibCompressor: MongoCompressor = JMongoCompressor.createZlibCompressor()
 }

--- a/driver/src/main/scala/org/mongodb/scala/MongoCompressor.scala
+++ b/driver/src/main/scala/org/mongodb/scala/MongoCompressor.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mongodb.scala
+
+import com.mongodb.{MongoCompressor => JMongoCompressor}
+
+/**
+ * Metadata describing a compressor to use for sending and receiving messages to a MongoDB server.
+ *
+ * @since 3.6
+ * @note Requires MongoDB 3.4 or greater
+ */
+object MongoCompressor {
+
+  /**
+   * Create an instance for snappy compression.
+   *
+   * @return A compressor based on the snappy compression algorithm
+   */
+  def createSnappyCompressor: MongoCompressor = JMongoCompressor.createSnappyCompressor()
+
+  /**
+   * Create an instance for zlib compression.
+   *
+   * @return A compressor based on the zlib compression algorithm
+   */
+  def createZlibCompressor: MongoCompressor = JMongoCompressor.createZlibCompressor()
+}

--- a/driver/src/main/scala/org/mongodb/scala/connection/AsynchronousSocketChannelStreamFactoryFactory.scala
+++ b/driver/src/main/scala/org/mongodb/scala/connection/AsynchronousSocketChannelStreamFactoryFactory.scala
@@ -25,5 +25,16 @@ import com.mongodb.connection.{AsynchronousSocketChannelStreamFactoryFactory => 
  * @since 1.0
  */
 object AsynchronousSocketChannelStreamFactoryFactory {
-  def apply(): StreamFactoryFactory = new JAsynchronousSocketChannelStreamFactoryFactory()
+  /**
+   * A `StreamFactoryFactory` implementation for AsynchronousSocketChannel-based streams.
+   */
+  def apply(): StreamFactoryFactory = JAsynchronousSocketChannelStreamFactoryFactory.builder().build()
+
+  /**
+   * Create a builder for AsynchronousSocketChannel-based streams
+   *
+   * @return the builder
+   * @since 2.2
+   */
+  def builder(): AsynchronousSocketChannelStreamFactoryFactoryBuilder = JAsynchronousSocketChannelStreamFactoryFactory.builder()
 }

--- a/driver/src/main/scala/org/mongodb/scala/connection/package.scala
+++ b/driver/src/main/scala/org/mongodb/scala/connection/package.scala
@@ -63,4 +63,23 @@ package object connection {
    */
   type AsynchronousSocketChannelStreamFactoryFactory = com.mongodb.connection.AsynchronousSocketChannelStreamFactoryFactory
 
+  /**
+   * A `StreamFactoryFactory` builder for AsynchronousSocketChannel-based streams.
+   *
+   * @see java.nio.channels.AsynchronousSocketChannel
+   * @since 2.2
+   */
+  type AsynchronousSocketChannelStreamFactoryFactoryBuilder = com.mongodb.connection.AsynchronousSocketChannelStreamFactoryFactory.Builder
+
+  /**
+   * A `StreamFactoryFactory` implementation for Netty-based streams.
+   * @since 2.2
+   */
+  type NettyStreamFactoryFactory = com.mongodb.connection.netty.NettyStreamFactoryFactory
+
+  /**
+   * A `StreamFactoryFactory` builder for Netty-based streams.
+   * @since 2.2
+   */
+  type NettyStreamFactoryFactoryBuilder = com.mongodb.connection.netty.NettyStreamFactoryFactory.Builder
 }

--- a/driver/src/main/scala/org/mongodb/scala/gridfs/GridFSBucket.scala
+++ b/driver/src/main/scala/org/mongodb/scala/gridfs/GridFSBucket.scala
@@ -19,11 +19,10 @@ package org.mongodb.scala.gridfs
 import org.bson.types.ObjectId
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.async.client.gridfs.{GridFSBuckets, GridFSBucket => JGridFSBucket}
-
 import org.mongodb.scala.bson.BsonValue
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.internal.ObservableHelper.{observe, observeCompleted, observeLong}
-import org.mongodb.scala.{Completed, MongoDatabase, Observable, ReadConcern, ReadPreference, WriteConcern}
+import org.mongodb.scala.{ClientSession, Completed, MongoDatabase, Observable, ReadConcern, ReadPreference, WriteConcern}
 
 /**
  * A factory for GridFSBucket instances.
@@ -136,7 +135,6 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * the application signals it is done writing the contents of the file by calling close on the returned Stream, a files collection
    * document is created in the files collection.
    *
-   *
    * @param filename the filename for the stream
    * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
    *         application will write the contents.
@@ -187,6 +185,78 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    */
   def openUploadStream(id: BsonValue, filename: String, options: GridFSUploadOptions): GridFSUploadStream =
     GridFSUploadStream(wrapped.openUploadStream(id, filename, options))
+
+  /**
+   * Opens a AsyncOutputStream that the application can write the contents of the file to.
+   *
+   * As the application writes the contents to the returned Stream, the contents are uploaded as chunks in the chunks collection. When
+   * the application signals it is done writing the contents of the file by calling close on the returned Stream, a files collection
+   * document is created in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filename the filename for the stream
+   * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
+   *         application will write the contents.
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def openUploadStream(clientSession: ClientSession, filename: String): GridFSUploadStream =
+    GridFSUploadStream(wrapped.openUploadStream(clientSession, filename))
+
+  /**
+   * Opens a AsyncOutputStream that the application can write the contents of the file to.
+   *
+   * As the application writes the contents to the returned Stream, the contents are uploaded as chunks in the chunks collection. When
+   * the application signals it is done writing the contents of the file by calling close on the returned Stream, a files collection
+   * document is created in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filename the filename for the stream
+   * @param options  the GridFSUploadOptions
+   * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
+   *         application will write the contents.
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def openUploadStream(clientSession: ClientSession, filename: String, options: GridFSUploadOptions): GridFSUploadStream =
+    GridFSUploadStream(wrapped.openUploadStream(clientSession, filename, options))
+
+  /**
+   * Opens a AsyncOutputStream that the application can write the contents of the file to.
+   *
+   * As the application writes the contents to the returned Stream, the contents are uploaded as chunks in the chunks collection. When
+   * the application signals it is done writing the contents of the file by calling close on the returned Stream, a files collection
+   * document is created in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id       the custom id value of the file
+   * @param filename the filename for the stream
+   * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
+   *         application will write the contents.
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def openUploadStream(clientSession: ClientSession, id: BsonValue, filename: String): GridFSUploadStream =
+    GridFSUploadStream(wrapped.openUploadStream(clientSession, id, filename))
+
+  /**
+   * Opens a AsyncOutputStream that the application can write the contents of the file to.
+   *
+   * As the application writes the contents to the returned Stream, the contents are uploaded as chunks in the chunks collection. When
+   * the application signals it is done writing the contents of the file by calling close on the returned Stream, a files collection
+   * document is created in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id       the custom id value of the file
+   * @param filename the filename for the stream
+   * @param options  the GridFSUploadOptions
+   * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
+   *         application will write the contents.
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def openUploadStream(clientSession: ClientSession, id: BsonValue, filename: String, options: GridFSUploadOptions): GridFSUploadStream =
+    GridFSUploadStream(wrapped.openUploadStream(clientSession, id, filename, options))
 
   /**
    * Uploads the contents of the given [[AsyncInputStream]] to a GridFS bucket.
@@ -245,6 +315,75 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
     observeCompleted(wrapped.uploadFromStream(id, filename, source, options, _: SingleResultCallback[Void]))
 
   /**
+   * Uploads the contents of the given `AsyncInputStream` to a GridFS bucket.
+   *
+   * Reads the contents of the user file from the `source` and uploads it as chunks in the chunks collection. After all the
+   * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filename the filename for the stream
+   * @param source   the Stream providing the file data
+   * @return a Observable returning a single element containing the ObjectId of the uploaded file.
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def uploadFromStream(clientSession: ClientSession, filename: String, source: AsyncInputStream): Observable[ObjectId] =
+    observe(wrapped.uploadFromStream(clientSession, filename, source, _: SingleResultCallback[ObjectId]))
+
+  /**
+   * Uploads the contents of the given `AsyncInputStream` to a GridFS bucket.
+   *
+   * Reads the contents of the user file from the `source` and uploads it as chunks in the chunks collection. After all the
+   * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filename the filename for the stream
+   * @param source   the Stream providing the file data
+   * @param options  the GridFSUploadOptions
+   * @return a Observable returning a single element containing the ObjectId of the uploaded file.
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def uploadFromStream(clientSession: ClientSession, filename: String, source: AsyncInputStream, options: GridFSUploadOptions): Observable[ObjectId] =
+    observe(wrapped.uploadFromStream(clientSession, filename, source, options, _: SingleResultCallback[ObjectId]))
+
+  /**
+   * Uploads the contents of the given `AsyncInputStream` to a GridFS bucket.
+   *
+   * Reads the contents of the user file from the `source` and uploads it as chunks in the chunks collection. After all the
+   * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id       the custom id value of the file
+   * @param filename the filename for the stream
+   * @param source   the Stream providing the file data
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def uploadFromStream(clientSession: ClientSession, id: BsonValue, filename: String, source: AsyncInputStream): Observable[Completed] =
+    observeCompleted(wrapped.uploadFromStream(clientSession, id, filename, source, _: SingleResultCallback[Void]))
+
+  /**
+   * Uploads the contents of the given `AsyncInputStream` to a GridFS bucket.
+   *
+   * Reads the contents of the user file from the `source` and uploads it as chunks in the chunks collection. After all the
+   * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id       the custom id value of the file
+   * @param filename the filename for the stream
+   * @param source   the Stream providing the file data
+   * @param options  the GridFSUploadOptions
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def uploadFromStream(clientSession: ClientSession, id: BsonValue, filename: String, source: AsyncInputStream,
+                       options: GridFSUploadOptions): Observable[Completed] =
+    observeCompleted(wrapped.uploadFromStream(clientSession, id, filename, source, options, _: SingleResultCallback[Void]))
+
+  /**
    * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by `id`.
    *
    * @param id the ObjectId of the file to be put into a stream.
@@ -253,34 +392,12 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
   def openDownloadStream(id: ObjectId): GridFSDownloadStream = GridFSDownloadStream(wrapped.openDownloadStream(id))
 
   /**
-   * Downloads the contents of the stored file specified by `id` and writes the contents to the `destination`
-   * AsyncOutputStream.
-   *
-   * @param id          the ObjectId of the file to be written to the destination stream
-   * @param destination the destination stream
-   * @return a Observable with a single element indicating the file has been downloaded
-   */
-  def downloadToStream(id: ObjectId, destination: AsyncOutputStream): Observable[Long] =
-    observeLong(wrapped.downloadToStream(id, destination, _: SingleResultCallback[java.lang.Long]))
-
-  /**
    * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by `id`.
    *
    * @param id the custom id value of the file, to be put into a stream.
    * @return the stream
    */
   def openDownloadStream(id: BsonValue): GridFSDownloadStream = GridFSDownloadStream(wrapped.openDownloadStream(id))
-
-  /**
-   * Downloads the contents of the stored file specified by `id` and writes the contents to the `destination`
-   * AsyncOutputStream.
-   *
-   * @param id          the custom id of the file, to be written to the destination stream
-   * @param destination the destination stream
-   * @return a Observable with a single element indicating the file has been downloaded
-   */
-  def downloadToStream(id: BsonValue, destination: AsyncOutputStream): Observable[Long] =
-    observeLong(wrapped.downloadToStream(id, destination, _: SingleResultCallback[java.lang.Long]))
 
   /**
    * Opens a Stream from which the application can read the contents of the latest version of the stored file specified by the
@@ -301,6 +418,79 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    */
   def openDownloadStream(filename: String, options: GridFSDownloadOptions): GridFSDownloadStream =
     GridFSDownloadStream(wrapped.openDownloadStream(filename, options))
+
+  /**
+   * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by `id`.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id the ObjectId of the file to be put into a stream.
+   * @return the stream
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def openDownloadStream(clientSession: ClientSession, id: ObjectId): GridFSDownloadStream =
+    GridFSDownloadStream(wrapped.openDownloadStream(clientSession, id))
+
+  /**
+   * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by `id`.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id the custom id value of the file, to be put into a stream.
+   * @return the stream
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def openDownloadStream(clientSession: ClientSession, id: BsonValue): GridFSDownloadStream =
+    GridFSDownloadStream(wrapped.openDownloadStream(clientSession, id))
+
+  /**
+   * Opens a Stream from which the application can read the contents of the latest version of the stored file specified by the
+   * `filename`.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filename the name of the file to be downloaded
+   * @return the stream
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def openDownloadStream(clientSession: ClientSession, filename: String): GridFSDownloadStream =
+    GridFSDownloadStream(wrapped.openDownloadStream(clientSession, filename))
+
+  /**
+   * Opens a Stream from which the application can read the contents of the stored file specified by `filename` and the revision
+   * in `options`.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filename the name of the file to be downloaded
+   * @param options  the download options
+   * @return the stream
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def openDownloadStream(clientSession: ClientSession, filename: String, options: GridFSDownloadOptions): GridFSDownloadStream =
+    GridFSDownloadStream(wrapped.openDownloadStream(clientSession, filename, options))
+
+  /**
+   * Downloads the contents of the stored file specified by `id` and writes the contents to the `destination`
+   * AsyncOutputStream.
+   *
+   * @param id          the ObjectId of the file to be written to the destination stream
+   * @param destination the destination stream
+   * @return a Observable with a single element indicating the file has been downloaded
+   */
+  def downloadToStream(id: ObjectId, destination: AsyncOutputStream): Observable[Long] =
+    observeLong(wrapped.downloadToStream(id, destination, _: SingleResultCallback[java.lang.Long]))
+
+  /**
+   * Downloads the contents of the stored file specified by `id` and writes the contents to the `destination`
+   * AsyncOutputStream.
+   *
+   * @param id          the custom id of the file, to be written to the destination stream
+   * @param destination the destination stream
+   * @return a Observable with a single element indicating the file has been downloaded
+   */
+  def downloadToStream(id: BsonValue, destination: AsyncOutputStream): Observable[Long] =
+    observeLong(wrapped.downloadToStream(id, destination, _: SingleResultCallback[java.lang.Long]))
 
   /**
    * Downloads the contents of the latest version of the stored file specified by `filename` and writes the contents to
@@ -326,6 +516,63 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
     observeLong(wrapped.downloadToStream(filename, destination, options, _: SingleResultCallback[java.lang.Long]))
 
   /**
+   * Downloads the contents of the stored file specified by `id` and writes the contents to the `destination`
+   * AsyncOutputStream.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id          the ObjectId of the file to be written to the destination stream
+   * @param destination the destination stream
+   * @return a Observable with a single element indicating the file has been downloaded
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def downloadToStream(clientSession: ClientSession, id: ObjectId, destination: AsyncOutputStream): Observable[Long] =
+    observeLong(wrapped.downloadToStream(clientSession, id, destination, _: SingleResultCallback[java.lang.Long]))
+
+  /**
+   * Downloads the contents of the stored file specified by `id` and writes the contents to the `destination`
+   * AsyncOutputStream.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id          the custom id of the file, to be written to the destination stream
+   * @param destination the destination stream
+   * @return a Observable with a single element indicating the file has been downloaded
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def downloadToStream(clientSession: ClientSession, id: BsonValue, destination: AsyncOutputStream): Observable[Long] =
+    observeLong(wrapped.downloadToStream(clientSession, id, destination, _: SingleResultCallback[java.lang.Long]))
+
+  /**
+   * Downloads the contents of the latest version of the stored file specified by `filename` and writes the contents to
+   * the `destination` Stream.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filename    the name of the file to be downloaded
+   * @param destination the destination stream
+   * @return a Observable with a single element indicating the file has been downloaded
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def downloadToStream(clientSession: ClientSession, filename: String, destination: AsyncOutputStream): Observable[Long] =
+    observeLong(wrapped.downloadToStream(clientSession, filename, destination, _: SingleResultCallback[java.lang.Long]))
+
+  /**
+   * Downloads the contents of the stored file specified by `filename` and by the revision in `options` and writes the
+   * contents to the `destination` Stream.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filename    the name of the file to be downloaded
+   * @param destination the destination stream
+   * @param options     the download options
+   * @return a Observable with a single element indicating the file has been downloaded
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def downloadToStream(clientSession: ClientSession, filename: String, destination: AsyncOutputStream, options: GridFSDownloadOptions): Observable[Long] =
+    observeLong(wrapped.downloadToStream(clientSession, filename, destination, options, _: SingleResultCallback[java.lang.Long]))
+
+  /**
    * Finds all documents in the files collection.
    *
    * @return the GridFS find iterable interface
@@ -349,6 +596,36 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
   def find(filter: Bson): GridFSFindObservable = GridFSFindObservable(wrapped.find(filter))
 
   /**
+   * Finds all documents in the files collection.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @return the GridFS find iterable interface
+   * @see [[http://docs.mongodb.org/manual/tutorial/query-documents/ Find]]
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def find(clientSession: ClientSession): GridFSFindObservable = GridFSFindObservable(wrapped.find(clientSession))
+
+  /**
+   * Finds all documents in the collection that match the filter.
+   *
+   * Below is an example of filtering against the filename and some nested metadata that can also be stored along with the file data:
+   *
+   * `
+   * Filters.and(Filters.eq("filename", "mongodb.png"), Filters.eq("metadata.contentType", "image/png"));
+   * `
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param filter the query filter
+   * @return the GridFS find iterable interface
+   * @see com.mongodb.client.model.Filters
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def find(clientSession: ClientSession, filter: Bson): GridFSFindObservable =
+    GridFSFindObservable(wrapped.find(clientSession, filter))
+
+  /**
    * Given a `id`, delete this stored file's files collection document and associated chunks from a GridFS bucket.
    *
    * @param id       the ObjectId of the file to be deleted
@@ -363,6 +640,30 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * @return a Observable with a single element indicating when the operation has completed
    */
   def delete(id: BsonValue): Observable[Completed] = observeCompleted(wrapped.delete(id, _: SingleResultCallback[Void]))
+
+  /**
+   * Given a `id`, delete this stored file's files collection document and associated chunks from a GridFS bucket.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id       the ObjectId of the file to be deleted
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def delete(clientSession: ClientSession, id: ObjectId): Observable[Completed] =
+    observeCompleted(wrapped.delete(clientSession, id, _: SingleResultCallback[Void]))
+
+  /**
+   * Given a `id`, delete this stored file's files collection document and associated chunks from a GridFS bucket.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id       the ObjectId of the file to be deleted
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def delete(clientSession: ClientSession, id: BsonValue): Observable[Completed] =
+    observeCompleted(wrapped.delete(clientSession, id, _: SingleResultCallback[Void]))
 
   /**
    * Renames the stored file with the specified `id`.
@@ -385,11 +686,46 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
     observeCompleted(wrapped.rename(id, newFilename, _: SingleResultCallback[Void]))
 
   /**
+   * Renames the stored file with the specified `id`.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id          the id of the file in the files collection to rename
+   * @param newFilename the new filename for the file
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def rename(clientSession: ClientSession, id: ObjectId, newFilename: String): Observable[Completed] =
+    observeCompleted(wrapped.rename(clientSession, id, newFilename, _: SingleResultCallback[Void]))
+
+  /**
+   * Renames the stored file with the specified `id`.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @param id          the id of the file in the files collection to rename
+   * @param newFilename the new filename for the file
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def rename(clientSession: ClientSession, id: BsonValue, newFilename: String): Observable[Completed] =
+    observeCompleted(wrapped.rename(clientSession, id, newFilename, _: SingleResultCallback[Void]))
+
+  /**
    * Drops the data associated with this bucket from the database.
    *
    * @return a Observable with a single element indicating when the operation has completed
    */
   def drop(): Observable[Completed] = observeCompleted(wrapped.drop(_: SingleResultCallback[Void]))
 
+  /**
+   * Drops the data associated with this bucket from the database.
+   *
+   * @param clientSession the client session with which to associate this operation
+   * @return a Observable with a single element indicating when the operation has completed
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def drop(clientSession: ClientSession): Observable[Completed] = observeCompleted(wrapped.drop(clientSession, _: SingleResultCallback[Void]))
 }
 // scalastyle:on number.of.methods

--- a/driver/src/main/scala/org/mongodb/scala/model/Filters.scala
+++ b/driver/src/main/scala/org/mongodb/scala/model/Filters.scala
@@ -49,7 +49,7 @@ object Filters {
   def eq[TItem](fieldName: String, value: TItem): Bson = JFilters.eq(fieldName, value)
 
   /**
-   * Creates a filter that matches all documents that validate against the given JSON schema document.
+   * Allows the use of aggregation expressions within the query language.
    *
    * @param expression the aggregation expression
    * @tparam TExpression the expression type

--- a/driver/src/main/scala/org/mongodb/scala/model/Filters.scala
+++ b/driver/src/main/scala/org/mongodb/scala/model/Filters.scala
@@ -49,6 +49,17 @@ object Filters {
   def eq[TItem](fieldName: String, value: TItem): Bson = JFilters.eq(fieldName, value)
 
   /**
+   * Creates a filter that matches all documents that validate against the given JSON schema document.
+   *
+   * @param expression the aggregation expression
+   * @tparam TExpression the expression type
+   * @return the filter
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def expr[TExpression](expression: TExpression): Bson = JFilters.expr(expression)
+
+  /**
    * Creates a filter that matches all documents where the value of the field name equals the specified value. Note that this does
    * actually generate a `\$eq` operator, as the query language doesn't require it.
    *
@@ -61,6 +72,16 @@ object Filters {
    * @see [[http://docs.mongodb.org/manual/reference/operator/query/eq \$eq]]
    */
   def equal[TItem](fieldName: String, value: TItem): Bson = eq(fieldName, value)
+
+  /**
+   * Creates a filter that matches all documents that validate against the given JSON schema document.
+   *
+   * @param schema the JSON schema to validate against
+   * @return the filter
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater
+   */
+  def jsonSchema(schema: Bson): Bson = JFilters.jsonSchema(schema)
 
   /**
    * Creates a filter that matches all documents where the value of the field name does not equal the specified value.

--- a/driver/src/main/scala/org/mongodb/scala/model/changestream/package.scala
+++ b/driver/src/main/scala/org/mongodb/scala/model/changestream/package.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mongodb.scala.model
+
+package object changestream {
+
+  /**
+   * Represents the `$changeStream` aggregation output document.
+   *
+   * '''Note:''' this class will not be applicable for all change stream outputs. If using custom pipelines that radically change the
+   * change stream result, then an alternative document format should be used.
+   *
+   * @tparam T  The type that this collection will encode the `fullDocument` field into.
+   */
+  type ChangeStreamDocument[T] = com.mongodb.client.model.changestream.ChangeStreamDocument[T]
+
+  /**
+   * Change Stream fullDocument configuration.
+   */
+  type FullDocument = com.mongodb.client.model.changestream.FullDocument
+}

--- a/driver/src/main/scala/org/mongodb/scala/model/package.scala
+++ b/driver/src/main/scala/org/mongodb/scala/model/package.scala
@@ -368,6 +368,20 @@ package object model {
   type IndexOptions = com.mongodb.client.model.IndexOptions
 
   /**
+   * The options to apply to the command when creating indexes.
+   *
+   * @since 2.2
+   */
+  type CreateIndexOptions = com.mongodb.client.model.CreateIndexOptions
+
+  /**
+   * The options to apply to the command when creating indexes.
+   *
+   * @since 2.2
+   */
+  type DropIndexOptions = com.mongodb.client.model.DropIndexOptions
+
+  /**
    * The options to apply to the creation of an index.
    */
   object IndexOptions {

--- a/driver/src/main/scala/org/mongodb/scala/package.scala
+++ b/driver/src/main/scala/org/mongodb/scala/package.scala
@@ -135,6 +135,25 @@ package object scala extends ObservableImplicits with WriteConcernImplicits {
    */
   type MongoClientSettings = com.mongodb.async.client.MongoClientSettings
 
+  /**
+   * A Client Session
+   *
+   * @since 2.2
+   */
+  type ClientSession = com.mongodb.session.ClientSession
+
+  /**
+   * Options for creating ClientSessions
+   * @since 2.2
+   */
+  type ClientSessionOptions = com.mongodb.ClientSessionOptions
+
+  /**
+   * Options for creating MongoCompressor
+   * @since 2.2
+   */
+  type MongoCompressor = com.mongodb.MongoCompressor
+
   // MongoException Aliases
   /**
    * Top level Exception for all Exceptions, server-side or client-side, that come from the driver.
@@ -145,6 +164,12 @@ package object scala extends ObservableImplicits with WriteConcernImplicits {
    * An exception that represents all errors associated with a bulk write operation.
    */
   type MongoBulkWriteException = com.mongodb.MongoBulkWriteException
+
+  /**
+   * An exception indicating that a failure occurred when running a `$changeStream`.
+   * @since 2.2
+   */
+  type MongoChangeStreamException = com.mongodb.MongoChangeStreamException
 
   /**
    * A base class for exceptions indicating a failure condition with the MongoClient.

--- a/driver/src/test/scala/org/mongodb/scala/AggregateObservableSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/AggregateObservableSpec.scala
@@ -48,26 +48,33 @@ class AggregateObservableSpec extends FlatSpec with Matchers with MockFactory {
 
   it should "call the underlying methods" in {
     val wrapper = mock[AggregateIterable[Document]]
-    val Observable = AggregateObservable(wrapper)
+    val observable = AggregateObservable(wrapper)
 
     val duration = Duration(1, TimeUnit.SECONDS)
     val collation = Collation.builder().locale("en").build()
+    val hint = Document("{hint: 1}")
 
     wrapper.expects('allowDiskUse)(true).once()
     wrapper.expects('useCursor)(true).once()
     wrapper.expects('maxTime)(duration.toMillis, TimeUnit.MILLISECONDS).once()
+    wrapper.expects('maxAwaitTime)(duration.toMillis, TimeUnit.MILLISECONDS).once()
     wrapper.expects('bypassDocumentValidation)(true).once()
     wrapper.expects('toCollection)(*).once()
     wrapper.expects('collation)(collation).once()
+    wrapper.expects('comment)("comment").once()
     wrapper.expects('batchSize)(Int.MaxValue).once()
     wrapper.expects('batchCursor)(*).once()
+    wrapper.expects('hint)(hint).once()
 
-    Observable.allowDiskUse(true)
-    Observable.useCursor(true)
-    Observable.maxTime(duration)
-    Observable.bypassDocumentValidation(true)
-    Observable.collation(collation)
-    Observable.toCollection().subscribe(observer[Completed])
-    Observable.subscribe(observer[Document])
+    observable.allowDiskUse(true)
+    observable.useCursor(true)
+    observable.maxTime(duration)
+    observable.maxAwaitTime(duration)
+    observable.bypassDocumentValidation(true)
+    observable.collation(collation)
+    observable.comment("comment")
+    observable.hint(hint)
+    observable.toCollection().subscribe(observer[Completed])
+    observable.subscribe(observer[Document])
   }
 }

--- a/driver/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
@@ -35,7 +35,7 @@ class ApiAliasAndCompanionSpec extends FlatSpec with Matchers {
     val packageName = "com.mongodb"
     val javaExclusions = Set("AsyncBatchCursor", "Block", "ConnectionString", "Function", "ServerCursor", "Majority", "MongoClients",
       "MongoIterable", "Observables", "SingleResultCallback", "GridFSBuckets", "DBRefCodec", "DBRefCodecProvider", "DBRef",
-      "DocumentToDBRefTransformer")
+      "DocumentToDBRefTransformer", "ServerSession", "SessionContext")
     val scalaExclusions = Set("package", "internal", "result", "Helpers", "Document", "BulkWriteResult", "ScalaObservable",
       "ScalaWriteConcern", "ObservableImplicits", "Completed", "BoxedObservable", "BoxedObserver", "BoxedSubscription",
       "classTagToClassOf", "ReadConcernLevel", "bsonDocumentToDocument", "bsonDocumentToUntypedDocument", "documentToUntypedDocument",
@@ -89,7 +89,8 @@ class ApiAliasAndCompanionSpec extends FlatSpec with Matchers {
     val javaExclusions = Set("AsyncCompletionHandler", "AsyncConnection", "AsynchronousSocketChannelStreamFactory", "BufferProvider",
       "Builder", "BulkWriteBatchCombiner", "ChangeEvent", "ChangeListener", "Cluster", "ClusterDescription", "ClusterFactory",
       "ClusterId", "Connection", "ConnectionDescription", "ConnectionId", "DefaultClusterFactory", "DefaultRandomStringGenerator",
-      "QueryResult", "RandomStringGenerator", "Server", "ServerDescription", "ServerId", "ServerVersion", "SocketStreamFactory", "Stream")
+      "QueryResult", "RandomStringGenerator", "Server", "ServerDescription", "ServerId", "ServerVersion", "SocketStreamFactory", "Stream",
+      "SplittablePayload")
 
     val filters = FilterBuilder.parse("-com.mongodb.connection.netty.*")
     val wrapped = new Reflections(new ConfigurationBuilder()
@@ -101,7 +102,9 @@ class ApiAliasAndCompanionSpec extends FlatSpec with Matchers {
       .map(_.getSimpleName).toSet -- javaExclusions
 
     val scalaPackageName = "org.mongodb.scala.connection"
-    val local = currentMirror.staticPackage(scalaPackageName).info.decls.map(_.name.toString).toSet - "package"
+    val scalaExclusions = Set("package", "NettyStreamFactoryFactory", "NettyStreamFactoryFactoryBuilder",
+      "AsynchronousSocketChannelStreamFactoryFactoryBuilder")
+    val local = currentMirror.staticPackage(scalaPackageName).info.decls.map(_.name.toString).toSet -- scalaExclusions
 
     diff(local, wrapped) shouldBe empty
   }

--- a/driver/src/test/scala/org/mongodb/scala/DistinctObservableSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/DistinctObservableSpec.scala
@@ -40,7 +40,7 @@ class DistinctObservableSpec extends FlatSpec with Matchers with MockFactory {
 
   it should "call the underlying methods" in {
     val wrapper = mock[DistinctIterable[Document]]
-    val Observable = DistinctObservable(wrapper)
+    val observable = DistinctObservable(wrapper)
 
     val filter = Document("a" -> 1)
     val duration = Duration(1, TimeUnit.SECONDS)
@@ -59,9 +59,9 @@ class DistinctObservableSpec extends FlatSpec with Matchers with MockFactory {
     wrapper.expects('batchSize)(Int.MaxValue).once()
     wrapper.expects('batchCursor)(*).once()
 
-    Observable.filter(filter)
-    Observable.maxTime(duration)
-    Observable.collation(collation)
-    Observable.subscribe(observer)
+    observable.filter(filter)
+    observable.maxTime(duration)
+    observable.collation(collation)
+    observable.subscribe(observer)
   }
 }

--- a/driver/src/test/scala/org/mongodb/scala/FindObservableSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/FindObservableSpec.scala
@@ -42,7 +42,7 @@ class FindObservableSpec extends FlatSpec with Matchers with MockFactory {
 
   it should "call the underlying methods" in {
     val wrapper = mock[FindIterable[Document]]
-    val Observable = FindObservable(wrapper)
+    val observable = FindObservable(wrapper)
 
     val filter = Document("a" -> 1)
     val duration = Duration(1, TimeUnit.SECONDS)
@@ -76,20 +76,20 @@ class FindObservableSpec extends FlatSpec with Matchers with MockFactory {
     wrapper.expects('batchSize)(Int.MaxValue).once()
     wrapper.expects('batchCursor)(*).once()
 
-    Observable.first().subscribe(observer)
-    Observable.filter(filter)
-    Observable.maxTime(duration)
-    Observable.maxAwaitTime(maxDuration)
-    Observable.limit(1)
-    Observable.skip(1)
-    Observable.modifiers(modifiers)
-    Observable.projection(projection)
-    Observable.sort(sort)
-    Observable.noCursorTimeout(true)
-    Observable.oplogReplay(true)
-    Observable.partial(true)
-    Observable.cursorType(CursorType.NonTailable)
-    Observable.collation(collation)
-    Observable.subscribe(observer)
+    observable.first().subscribe(observer)
+    observable.filter(filter)
+    observable.maxTime(duration)
+    observable.maxAwaitTime(maxDuration)
+    observable.limit(1)
+    observable.skip(1)
+    observable.modifiers(modifiers)
+    observable.projection(projection)
+    observable.sort(sort)
+    observable.noCursorTimeout(true)
+    observable.oplogReplay(true)
+    observable.partial(true)
+    observable.cursorType(CursorType.NonTailable)
+    observable.collation(collation)
+    observable.subscribe(observer)
   }
 }

--- a/driver/src/test/scala/org/mongodb/scala/ListCollectionsObservableSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/ListCollectionsObservableSpec.scala
@@ -39,7 +39,7 @@ class ListCollectionsObservableSpec extends FlatSpec with Matchers with MockFact
 
   it should "call the underlying methods" in {
     val wrapper = mock[ListCollectionsIterable[Document]]
-    val Observable = ListCollectionsObservable(wrapper)
+    val observable = ListCollectionsObservable(wrapper)
 
     val filter = Document("a" -> 1)
     val duration = Duration(1, TimeUnit.SECONDS)
@@ -55,8 +55,8 @@ class ListCollectionsObservableSpec extends FlatSpec with Matchers with MockFact
     wrapper.expects('batchSize)(Int.MaxValue).once()
     wrapper.expects('batchCursor)(*).once()
 
-    Observable.filter(filter)
-    Observable.maxTime(duration)
-    Observable.subscribe(observer)
+    observable.filter(filter)
+    observable.maxTime(duration)
+    observable.subscribe(observer)
   }
 }

--- a/driver/src/test/scala/org/mongodb/scala/ListDatabasesObservableSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/ListDatabasesObservableSpec.scala
@@ -39,7 +39,8 @@ class ListDatabasesObservableSpec extends FlatSpec with Matchers with MockFactor
 
   it should "call the underlying methods" in {
     val wrapper = mock[ListDatabasesIterable[Document]]
-    val Observable = ListDatabasesObservable(wrapper)
+    val observable = ListDatabasesObservable(wrapper)
+    val filter = Document("{a: 1}")
 
     val duration = Duration(1, TimeUnit.SECONDS)
     val observer = new Observer[Document]() {
@@ -50,10 +51,14 @@ class ListDatabasesObservableSpec extends FlatSpec with Matchers with MockFactor
     }
 
     wrapper.expects('maxTime)(duration.toMillis, TimeUnit.MILLISECONDS).once()
+    wrapper.expects('filter)(filter).once()
+    wrapper.expects('nameOnly)(true).once()
     wrapper.expects('batchSize)(Int.MaxValue).once()
     wrapper.expects('batchCursor)(*).once()
 
-    Observable.maxTime(duration)
-    Observable.subscribe(observer)
+    observable.maxTime(duration)
+    observable.filter(filter)
+    observable.nameOnly(true)
+    observable.subscribe(observer)
   }
 }

--- a/driver/src/test/scala/org/mongodb/scala/ListIndexesObservableSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/ListIndexesObservableSpec.scala
@@ -39,7 +39,7 @@ class ListIndexesObservableSpec extends FlatSpec with Matchers with MockFactory 
 
   it should "call the underlying methods" in {
     val wrapper = mock[ListIndexesIterable[Document]]
-    val Observable = ListIndexesObservable(wrapper)
+    val observable = ListIndexesObservable(wrapper)
 
     val duration = Duration(1, TimeUnit.SECONDS)
     val observer = new Observer[Document]() {
@@ -53,7 +53,7 @@ class ListIndexesObservableSpec extends FlatSpec with Matchers with MockFactory 
     wrapper.expects('batchSize)(Int.MaxValue).once()
     wrapper.expects('batchCursor)(*).once()
 
-    Observable.maxTime(duration)
-    Observable.subscribe(observer)
+    observable.maxTime(duration)
+    observable.subscribe(observer)
   }
 }

--- a/driver/src/test/scala/org/mongodb/scala/MapReduceObservableSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/MapReduceObservableSpec.scala
@@ -48,7 +48,7 @@ class MapReduceObservableSpec extends FlatSpec with Matchers with MockFactory {
 
   it should "call the underlying methods" in {
     val wrapper = mock[MapReduceIterable[Document]]
-    val Observable = MapReduceObservable(wrapper)
+    val observable = MapReduceObservable(wrapper)
 
     val filter = Document("a" -> 1)
     val duration = Duration(1, TimeUnit.SECONDS)
@@ -75,22 +75,22 @@ class MapReduceObservableSpec extends FlatSpec with Matchers with MockFactory {
     wrapper.expects('batchSize)(Int.MaxValue).once()
     wrapper.expects('batchCursor)(*).once()
 
-    Observable.filter(filter)
-    Observable.scope(scope)
-    Observable.sort(sort)
-    Observable.limit(1)
-    Observable.maxTime(duration)
-    Observable.collectionName("collectionName")
-    Observable.databaseName("databaseName")
-    Observable.finalizeFunction("final")
-    Observable.action(MapReduceAction.REPLACE)
-    Observable.jsMode(true)
-    Observable.verbose(true)
-    Observable.sharded(true)
-    Observable.nonAtomic(true)
-    Observable.bypassDocumentValidation(true)
-    Observable.collation(collation)
-    Observable.toCollection().subscribe(observer[Completed])
-    Observable.subscribe(observer[Document])
+    observable.filter(filter)
+    observable.scope(scope)
+    observable.sort(sort)
+    observable.limit(1)
+    observable.maxTime(duration)
+    observable.collectionName("collectionName")
+    observable.databaseName("databaseName")
+    observable.finalizeFunction("final")
+    observable.action(MapReduceAction.REPLACE)
+    observable.jsMode(true)
+    observable.verbose(true)
+    observable.sharded(true)
+    observable.nonAtomic(true)
+    observable.bypassDocumentValidation(true)
+    observable.collation(collation)
+    observable.toCollection().subscribe(observer[Completed])
+    observable.subscribe(observer[Document])
   }
 }

--- a/driver/src/test/scala/org/mongodb/scala/MongoCollectionSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/MongoCollectionSpec.scala
@@ -32,6 +32,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
   val wrapped = mock[JMongoCollection[Document]]
+  val clientSession = mock[ClientSession]
   val mongoCollection = MongoCollection[Document](wrapped)
   val readPreference = ReadPreference.secondary()
   val collation = Collation.builder().locale("en").build()
@@ -134,32 +135,48 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
     wrapped.expects('count)(*).once()
     wrapped.expects('count)(filter, *).once()
     wrapped.expects('count)(filter, countOptions, *).once()
+    wrapped.expects('count)(clientSession, *).once()
+    wrapped.expects('count)(clientSession, filter, *).once()
+    wrapped.expects('count)(clientSession, filter, countOptions, *).once()
 
     mongoCollection.count().subscribe(observer[Long])
     mongoCollection.count(filter).subscribe(observer[Long])
     mongoCollection.count(filter, countOptions).subscribe(observer[Long])
+    mongoCollection.count(clientSession).subscribe(observer[Long])
+    mongoCollection.count(clientSession, filter).subscribe(observer[Long])
+    mongoCollection.count(clientSession, filter, countOptions).subscribe(observer[Long])
   }
 
   it should "wrap the underlying DistinctObservable correctly" in {
     wrapped.expects('distinct)("fieldName", classOf[String]).once()
     wrapped.expects('distinct)("fieldName", filter, classOf[String]).once()
+    wrapped.expects('distinct)(clientSession, "fieldName", classOf[String]).once()
+    wrapped.expects('distinct)(clientSession, "fieldName", filter, classOf[String]).once()
 
     mongoCollection.distinct[String]("fieldName")
     mongoCollection.distinct[String]("fieldName", filter)
+    mongoCollection.distinct[String](clientSession, "fieldName")
+    mongoCollection.distinct[String](clientSession, "fieldName", filter)
   }
 
   it should "wrap the underlying FindObservable correctly" in {
     wrapped.expects('find)(classOf[Document]).once()
     wrapped.expects('find)(classOf[BsonDocument]).once()
+    wrapped.expects('find)(filter, classOf[Document]).once()
+    wrapped.expects('find)(filter, classOf[BsonDocument]).once()
+    wrapped.expects('find)(clientSession, classOf[Document]).once()
+    wrapped.expects('find)(clientSession, classOf[BsonDocument]).once()
+    wrapped.expects('find)(clientSession, filter, classOf[Document]).once()
+    wrapped.expects('find)(clientSession, filter, classOf[BsonDocument]).once()
 
     mongoCollection.find() shouldBe a[FindObservable[_]]
     mongoCollection.find[BsonDocument]() shouldBe a[FindObservable[_]]
-
-    wrapped.expects('find)(filter, classOf[Document]).once()
-    wrapped.expects('find)(filter, classOf[BsonDocument]).once()
-
     mongoCollection.find(filter) shouldBe a[FindObservable[_]]
     mongoCollection.find[BsonDocument](filter) shouldBe a[FindObservable[_]]
+    mongoCollection.find(clientSession) shouldBe a[FindObservable[_]]
+    mongoCollection.find[BsonDocument](clientSession) shouldBe a[FindObservable[_]]
+    mongoCollection.find(clientSession, filter) shouldBe a[FindObservable[_]]
+    mongoCollection.find[BsonDocument](clientSession, filter) shouldBe a[FindObservable[_]]
   }
 
   it should "wrap the underlying AggregateObservable correctly" in {
@@ -167,17 +184,25 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('aggregate)(pipeline.asJava, classOf[Document]).once()
     wrapped.expects('aggregate)(pipeline.asJava, classOf[BsonDocument]).once()
+    wrapped.expects('aggregate)(clientSession, pipeline.asJava, classOf[Document]).once()
+    wrapped.expects('aggregate)(clientSession, pipeline.asJava, classOf[BsonDocument]).once()
 
     mongoCollection.aggregate(pipeline) shouldBe a[AggregateObservable[_]]
     mongoCollection.aggregate[BsonDocument](pipeline) shouldBe a[AggregateObservable[_]]
+    mongoCollection.aggregate(clientSession, pipeline) shouldBe a[AggregateObservable[_]]
+    mongoCollection.aggregate[BsonDocument](clientSession, pipeline) shouldBe a[AggregateObservable[_]]
   }
 
   it should "wrap the underlying MapReduceObservable correctly" in {
     wrapped.expects('mapReduce)("map", "reduce", classOf[Document]).once()
     wrapped.expects('mapReduce)("map", "reduce", classOf[BsonDocument]).once()
+    wrapped.expects('mapReduce)(clientSession, "map", "reduce", classOf[Document]).once()
+    wrapped.expects('mapReduce)(clientSession, "map", "reduce", classOf[BsonDocument]).once()
 
     mongoCollection.mapReduce("map", "reduce") shouldBe a[MapReduceObservable[_]]
     mongoCollection.mapReduce[BsonDocument]("map", "reduce") shouldBe a[MapReduceObservable[_]]
+    mongoCollection.mapReduce(clientSession, "map", "reduce") shouldBe a[MapReduceObservable[_]]
+    mongoCollection.mapReduce[BsonDocument](clientSession, "map", "reduce") shouldBe a[MapReduceObservable[_]]
   }
 
   it should "wrap the underlying bulkWrite correctly" in {
@@ -190,21 +215,27 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('bulkWrite)(bulkRequests.asJava, *).once()
     wrapped.expects('bulkWrite)(bulkRequests.asJava, bulkWriteOptions, *).once()
+    wrapped.expects('bulkWrite)(clientSession, bulkRequests.asJava, *).once()
+    wrapped.expects('bulkWrite)(clientSession, bulkRequests.asJava, bulkWriteOptions, *).once()
 
     mongoCollection.bulkWrite(bulkRequests).subscribe(observer[BulkWriteResult])
     mongoCollection.bulkWrite(bulkRequests, bulkWriteOptions).subscribe(observer[BulkWriteResult])
+    mongoCollection.bulkWrite(clientSession, bulkRequests).subscribe(observer[BulkWriteResult])
+    mongoCollection.bulkWrite(clientSession, bulkRequests, bulkWriteOptions).subscribe(observer[BulkWriteResult])
   }
 
   it should "wrap the underlying insertOne correctly" in {
     val insertDoc = Document("a" -> 1)
     val insertOptions = InsertOneOptions().bypassDocumentValidation(true)
     wrapped.expects('insertOne)(insertDoc, *).once()
+    wrapped.expects('insertOne)(insertDoc, insertOptions, *).once()
+    wrapped.expects('insertOne)(clientSession, insertDoc, *).once()
+    wrapped.expects('insertOne)(clientSession, insertDoc, insertOptions, *).once()
 
     mongoCollection.insertOne(insertDoc).subscribe(observer[Completed])
-
-    wrapped.expects('insertOne)(insertDoc, insertOptions, *).once()
-
     mongoCollection.insertOne(insertDoc, insertOptions).subscribe(observer[Completed])
+    mongoCollection.insertOne(clientSession, insertDoc).subscribe(observer[Completed])
+    mongoCollection.insertOne(clientSession, insertDoc, insertOptions).subscribe(observer[Completed])
   }
 
   it should "wrap the underlying insertMany correctly" in {
@@ -213,27 +244,39 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('insertMany)(insertDocs.asJava, *).once()
     wrapped.expects('insertMany)(insertDocs.asJava, insertOptions, *).once()
+    wrapped.expects('insertMany)(clientSession, insertDocs.asJava, *).once()
+    wrapped.expects('insertMany)(clientSession, insertDocs.asJava, insertOptions, *).once()
 
     mongoCollection.insertMany(insertDocs).subscribe(observer[Completed])
     mongoCollection.insertMany(insertDocs, insertOptions).subscribe(observer[Completed])
+    mongoCollection.insertMany(clientSession, insertDocs).subscribe(observer[Completed])
+    mongoCollection.insertMany(clientSession, insertDocs, insertOptions).subscribe(observer[Completed])
   }
 
   it should "wrap the underlying deleteOne correctly" in {
     val options = new DeleteOptions().collation(collation)
     wrapped.expects('deleteOne)(filter, *).once()
     wrapped.expects('deleteOne)(filter, options, *).once()
+    wrapped.expects('deleteOne)(clientSession, filter, *).once()
+    wrapped.expects('deleteOne)(clientSession, filter, options, *).once()
 
     mongoCollection.deleteOne(filter).subscribe(observer[DeleteResult])
     mongoCollection.deleteOne(filter, options).subscribe(observer[DeleteResult])
+    mongoCollection.deleteOne(clientSession, filter).subscribe(observer[DeleteResult])
+    mongoCollection.deleteOne(clientSession, filter, options).subscribe(observer[DeleteResult])
   }
 
   it should "wrap the underlying deleteMany correctly" in {
     val options = new DeleteOptions().collation(collation)
     wrapped.expects('deleteMany)(filter, *).once()
     wrapped.expects('deleteMany)(filter, options, *).once()
+    wrapped.expects('deleteMany)(clientSession, filter, *).once()
+    wrapped.expects('deleteMany)(clientSession, filter, options, *).once()
 
     mongoCollection.deleteMany(filter).subscribe(observer[DeleteResult])
     mongoCollection.deleteMany(filter, options).subscribe(observer[DeleteResult])
+    mongoCollection.deleteMany(clientSession, filter).subscribe(observer[DeleteResult])
+    mongoCollection.deleteMany(clientSession, filter, options).subscribe(observer[DeleteResult])
   }
 
   it should "wrap the underlying replaceOne correctly" in {
@@ -242,9 +285,13 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('replaceOne)(filter, replacement, *).once()
     wrapped.expects('replaceOne)(filter, replacement, updateOptions, *).once()
+    wrapped.expects('replaceOne)(clientSession, filter, replacement, *).once()
+    wrapped.expects('replaceOne)(clientSession, filter, replacement, updateOptions, *).once()
 
     mongoCollection.replaceOne(filter, replacement).subscribe(observer[UpdateResult])
     mongoCollection.replaceOne(filter, replacement, updateOptions).subscribe(observer[UpdateResult])
+    mongoCollection.replaceOne(clientSession, filter, replacement).subscribe(observer[UpdateResult])
+    mongoCollection.replaceOne(clientSession, filter, replacement, updateOptions).subscribe(observer[UpdateResult])
   }
 
   it should "wrap the underlying updateOne correctly" in {
@@ -253,9 +300,13 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('updateOne)(filter, update, *).once()
     wrapped.expects('updateOne)(filter, update, updateOptions, *).once()
+    wrapped.expects('updateOne)(clientSession, filter, update, *).once()
+    wrapped.expects('updateOne)(clientSession, filter, update, updateOptions, *).once()
 
     mongoCollection.updateOne(filter, update).subscribe(observer[UpdateResult])
     mongoCollection.updateOne(filter, update, updateOptions).subscribe(observer[UpdateResult])
+    mongoCollection.updateOne(clientSession, filter, update).subscribe(observer[UpdateResult])
+    mongoCollection.updateOne(clientSession, filter, update, updateOptions).subscribe(observer[UpdateResult])
   }
 
   it should "wrap the underlying updateMany correctly" in {
@@ -264,9 +315,13 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('updateMany)(filter, update, *).once()
     wrapped.expects('updateMany)(filter, update, updateOptions, *).once()
+    wrapped.expects('updateMany)(clientSession, filter, update, *).once()
+    wrapped.expects('updateMany)(clientSession, filter, update, updateOptions, *).once()
 
     mongoCollection.updateMany(filter, update).subscribe(observer[UpdateResult])
     mongoCollection.updateMany(filter, update, updateOptions).subscribe(observer[UpdateResult])
+    mongoCollection.updateMany(clientSession, filter, update).subscribe(observer[UpdateResult])
+    mongoCollection.updateMany(clientSession, filter, update, updateOptions).subscribe(observer[UpdateResult])
   }
 
   it should "wrap the underlying findOneAndDelete correctly" in {
@@ -274,9 +329,13 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('findOneAndDelete)(filter, *).once()
     wrapped.expects('findOneAndDelete)(filter, options, *).once()
+    wrapped.expects('findOneAndDelete)(clientSession, filter, *).once()
+    wrapped.expects('findOneAndDelete)(clientSession, filter, options, *).once()
 
     mongoCollection.findOneAndDelete(filter).subscribe(observer[Document])
     mongoCollection.findOneAndDelete(filter, options).subscribe(observer[Document])
+    mongoCollection.findOneAndDelete(clientSession, filter).subscribe(observer[Document])
+    mongoCollection.findOneAndDelete(clientSession, filter, options).subscribe(observer[Document])
   }
 
   it should "wrap the underlying findOneAndReplace correctly" in {
@@ -285,9 +344,13 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('findOneAndReplace)(filter, replacement, *).once()
     wrapped.expects('findOneAndReplace)(filter, replacement, options, *).once()
+    wrapped.expects('findOneAndReplace)(clientSession, filter, replacement, *).once()
+    wrapped.expects('findOneAndReplace)(clientSession, filter, replacement, options, *).once()
 
     mongoCollection.findOneAndReplace(filter, replacement).subscribe(observer[Document])
     mongoCollection.findOneAndReplace(filter, replacement, options).subscribe(observer[Document])
+    mongoCollection.findOneAndReplace(clientSession, filter, replacement).subscribe(observer[Document])
+    mongoCollection.findOneAndReplace(clientSession, filter, replacement, options).subscribe(observer[Document])
   }
 
   it should "wrap the underlying findOneAndUpdate correctly" in {
@@ -296,15 +359,21 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('findOneAndUpdate)(filter, update, *).once()
     wrapped.expects('findOneAndUpdate)(filter, update, options, *).once()
+    wrapped.expects('findOneAndUpdate)(clientSession, filter, update, *).once()
+    wrapped.expects('findOneAndUpdate)(clientSession, filter, update, options, *).once()
 
     mongoCollection.findOneAndUpdate(filter, update).subscribe(observer[Document])
     mongoCollection.findOneAndUpdate(filter, update, options).subscribe(observer[Document])
+    mongoCollection.findOneAndUpdate(clientSession, filter, update).subscribe(observer[Document])
+    mongoCollection.findOneAndUpdate(clientSession, filter, update, options).subscribe(observer[Document])
   }
 
   it should "wrap the underlying drop correctly" in {
     wrapped.expects('drop)(*).once()
+    wrapped.expects('drop)(clientSession, *).once()
 
     mongoCollection.drop().subscribe(observer[Completed])
+    mongoCollection.drop(clientSession).subscribe(observer[Completed])
   }
 
   it should "wrap the underlying createIndex correctly" in {
@@ -313,43 +382,77 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('createIndex)(index, *).once()
     wrapped.expects('createIndex)(index, options, *).once()
+    wrapped.expects('createIndex)(clientSession, index, *).once()
+    wrapped.expects('createIndex)(clientSession, index, options, *).once()
 
     mongoCollection.createIndex(index).subscribe(observer[String])
     mongoCollection.createIndex(index, options).subscribe(observer[String])
+    mongoCollection.createIndex(clientSession, index).subscribe(observer[String])
+    mongoCollection.createIndex(clientSession, index, options).subscribe(observer[String])
   }
 
   it should "wrap the underlying createIndexes correctly" in {
     val indexes = new IndexModel(Document("a" -> 1))
+    val options = new CreateIndexOptions()
 
     // https://github.com/paulbutcher/ScalaMock/issues/93
     wrapped.expects('createIndexes)(List(indexes).asJava, *).once()
+    wrapped.expects('createIndexes)(List(indexes).asJava, options, *).once()
+    wrapped.expects('createIndexes)(clientSession, List(indexes).asJava, *).once()
+    wrapped.expects('createIndexes)(clientSession, List(indexes).asJava, options, *).once()
 
     mongoCollection.createIndexes(List(indexes)).subscribe(observer[String])
+    mongoCollection.createIndexes(List(indexes), options).subscribe(observer[String])
+    mongoCollection.createIndexes(clientSession, List(indexes)).subscribe(observer[String])
+    mongoCollection.createIndexes(clientSession, List(indexes), options).subscribe(observer[String])
   }
 
   it should "wrap the underlying listIndexes correctly" in {
     wrapped.expects('listIndexes)(classOf[Document]).once()
     wrapped.expects('listIndexes)(classOf[BsonDocument]).once()
+    wrapped.expects('listIndexes)(clientSession, classOf[Document]).once()
+    wrapped.expects('listIndexes)(clientSession, classOf[BsonDocument]).once()
 
     mongoCollection.listIndexes()
     mongoCollection.listIndexes[BsonDocument]()
+    mongoCollection.listIndexes(clientSession)
+    mongoCollection.listIndexes[BsonDocument](clientSession)
   }
 
   it should "wrap the underlying dropIndex correctly" in {
+    val indexDocument = Document("""{a: 1}""")
+    val options = new DropIndexOptions()
     wrapped.expects('dropIndex)("indexName", *).once()
+    wrapped.expects('dropIndex)(indexDocument, *).once()
+    wrapped.expects('dropIndex)("indexName", options, *).once()
+    wrapped.expects('dropIndex)(indexDocument, options, *).once()
+    wrapped.expects('dropIndex)(clientSession, "indexName", *).once()
+    wrapped.expects('dropIndex)(clientSession, indexDocument, *).once()
+    wrapped.expects('dropIndex)(clientSession, "indexName", options, *).once()
+    wrapped.expects('dropIndex)(clientSession, indexDocument, options, *).once()
 
     mongoCollection.dropIndex("indexName").subscribe(observer[Completed])
-
-    val indexDocument = Document("""{a: 1}""")
-    wrapped.expects('dropIndex)(indexDocument, *).once()
-
     mongoCollection.dropIndex(indexDocument).subscribe(observer[Completed])
+    mongoCollection.dropIndex("indexName", options).subscribe(observer[Completed])
+    mongoCollection.dropIndex(indexDocument, options).subscribe(observer[Completed])
+    mongoCollection.dropIndex(clientSession, "indexName").subscribe(observer[Completed])
+    mongoCollection.dropIndex(clientSession, indexDocument).subscribe(observer[Completed])
+    mongoCollection.dropIndex(clientSession, "indexName", options).subscribe(observer[Completed])
+    mongoCollection.dropIndex(clientSession, indexDocument, options).subscribe(observer[Completed])
   }
 
   it should "wrap the underlying dropIndexes correctly" in {
+
+    val options = new DropIndexOptions()
     wrapped.expects('dropIndexes)(*).once()
+    wrapped.expects('dropIndexes)(options, *).once()
+    wrapped.expects('dropIndexes)(clientSession, *).once()
+    wrapped.expects('dropIndexes)(clientSession, options, *).once()
 
     mongoCollection.dropIndexes().subscribe(observer[Completed])
+    mongoCollection.dropIndexes(options).subscribe(observer[Completed])
+    mongoCollection.dropIndexes(clientSession).subscribe(observer[Completed])
+    mongoCollection.dropIndexes(clientSession, options).subscribe(observer[Completed])
   }
 
   it should "wrap the underlying renameCollection correctly" in {
@@ -358,9 +461,35 @@ class MongoCollectionSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapped.expects('renameCollection)(newNamespace, *).once()
     wrapped.expects('renameCollection)(newNamespace, options, *).once()
+    wrapped.expects('renameCollection)(clientSession, newNamespace, *).once()
+    wrapped.expects('renameCollection)(clientSession, newNamespace, options, *).once()
 
     mongoCollection.renameCollection(newNamespace).subscribe(observer[Completed])
     mongoCollection.renameCollection(newNamespace, options).subscribe(observer[Completed])
+    mongoCollection.renameCollection(clientSession, newNamespace).subscribe(observer[Completed])
+    mongoCollection.renameCollection(clientSession, newNamespace, options).subscribe(observer[Completed])
+  }
+
+  it should "wrap the underlying ChangeStreamIterable correctly" in {
+    val pipeline = List(Document("$match" -> 1))
+
+    wrapped.expects('watch)(classOf[Document]).once()
+    wrapped.expects('watch)(classOf[BsonDocument]).once()
+    wrapped.expects('watch)(pipeline.asJava, classOf[Document]).once()
+    wrapped.expects('watch)(pipeline.asJava, classOf[BsonDocument]).once()
+    wrapped.expects('watch)(clientSession, classOf[Document]).once()
+    wrapped.expects('watch)(clientSession, classOf[BsonDocument]).once()
+    wrapped.expects('watch)(clientSession, pipeline.asJava, classOf[Document]).once()
+    wrapped.expects('watch)(clientSession, pipeline.asJava, classOf[BsonDocument]).once()
+
+    mongoCollection.watch() shouldBe a[ChangeStreamObservable[_]]
+    mongoCollection.watch[BsonDocument]() shouldBe a[ChangeStreamObservable[_]]
+    mongoCollection.watch(pipeline) shouldBe a[ChangeStreamObservable[_]]
+    mongoCollection.watch[BsonDocument](pipeline) shouldBe a[ChangeStreamObservable[_]]
+    mongoCollection.watch(clientSession) shouldBe a[ChangeStreamObservable[_]]
+    mongoCollection.watch[BsonDocument](clientSession) shouldBe a[ChangeStreamObservable[_]]
+    mongoCollection.watch(clientSession, pipeline) shouldBe a[ChangeStreamObservable[_]]
+    mongoCollection.watch[BsonDocument](clientSession, pipeline) shouldBe a[ChangeStreamObservable[_]]
   }
 
 }

--- a/driver/src/test/scala/org/mongodb/scala/gridfs/GridFSBucketSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/gridfs/GridFSBucketSpec.scala
@@ -18,15 +18,15 @@ package org.mongodb.scala.gridfs
 
 import org.bson.types.ObjectId
 import com.mongodb.async.client.gridfs.{GridFSBucket => JGridFSBucket}
-
 import org.mongodb.scala.bson.BsonObjectId
 import org.mongodb.scala.bson.collection.immutable.Document
-import org.mongodb.scala.{ReadConcern, ReadPreference, WriteConcern}
+import org.mongodb.scala.{ClientSession, ReadConcern, ReadPreference, WriteConcern}
 import org.scalamock.scalatest.proxy.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
 
 class GridFSBucketSpec extends FlatSpec with Matchers with MockFactory {
   val wrapper = mock[JGridFSBucket]
+  val clientSession = mock[ClientSession]
   val gridFSBucket = new GridFSBucket(wrapper)
 
   "GridFSBucket" should "have the same methods as the wrapped GridFSBucket" in {
@@ -76,15 +76,21 @@ class GridFSBucketSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapper.expects('delete)(objectId, *).once()
     wrapper.expects('delete)(bsonValue, *).once()
+    wrapper.expects('delete)(clientSession, objectId, *).once()
+    wrapper.expects('delete)(clientSession, bsonValue, *).once()
 
     gridFSBucket.delete(objectId).head()
     gridFSBucket.delete(bsonValue).head()
+    gridFSBucket.delete(clientSession, objectId).head()
+    gridFSBucket.delete(clientSession, bsonValue).head()
   }
 
   it should "call the underlying drop method" in {
     wrapper.expects('drop)(*).once()
+    wrapper.expects('drop)(clientSession, *).once()
 
     gridFSBucket.drop().head()
+    gridFSBucket.drop(clientSession).head()
   }
 
   it should "call the underlying rename method" in {
@@ -94,9 +100,13 @@ class GridFSBucketSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapper.expects('rename)(objectId, newName, *).once()
     wrapper.expects('rename)(bsonValue, newName, *).once()
+    wrapper.expects('rename)(clientSession, objectId, newName, *).once()
+    wrapper.expects('rename)(clientSession, bsonValue, newName, *).once()
 
     gridFSBucket.rename(objectId, newName).head()
     gridFSBucket.rename(bsonValue, newName).head()
+    gridFSBucket.rename(clientSession, objectId, newName).head()
+    gridFSBucket.rename(clientSession, bsonValue, newName).head()
   }
 
   it should "return the expected findObservable" in {
@@ -104,9 +114,13 @@ class GridFSBucketSpec extends FlatSpec with Matchers with MockFactory {
 
     wrapper.expects('find)().once()
     wrapper.expects('find)(filter).once()
+    wrapper.expects('find)(clientSession).once()
+    wrapper.expects('find)(clientSession, filter).once()
 
     gridFSBucket.find().head()
     gridFSBucket.find(filter).head()
+    gridFSBucket.find(clientSession).head()
+    gridFSBucket.find(clientSession, filter).head()
   }
 
   it should "create the expected GridFSDownloadStream" in {
@@ -119,11 +133,19 @@ class GridFSBucketSpec extends FlatSpec with Matchers with MockFactory {
     wrapper.expects('openDownloadStream)(filename, options)
     wrapper.expects('openDownloadStream)(objectId)
     wrapper.expects('openDownloadStream)(bsonValue)
+    wrapper.expects('openDownloadStream)(clientSession, filename)
+    wrapper.expects('openDownloadStream)(clientSession, filename, options)
+    wrapper.expects('openDownloadStream)(clientSession, objectId)
+    wrapper.expects('openDownloadStream)(clientSession, bsonValue)
 
     gridFSBucket.openDownloadStream(filename)
     gridFSBucket.openDownloadStream(filename, options)
     gridFSBucket.openDownloadStream(objectId)
     gridFSBucket.openDownloadStream(bsonValue)
+    gridFSBucket.openDownloadStream(clientSession, filename)
+    gridFSBucket.openDownloadStream(clientSession, filename, options)
+    gridFSBucket.openDownloadStream(clientSession, objectId)
+    gridFSBucket.openDownloadStream(clientSession, bsonValue)
   }
 
   it should "downloadToStream as expected" in {
@@ -137,11 +159,19 @@ class GridFSBucketSpec extends FlatSpec with Matchers with MockFactory {
     wrapper.expects('downloadToStream)(filename, *, options, *)
     wrapper.expects('downloadToStream)(objectId, *, *)
     wrapper.expects('downloadToStream)(bsonValue, *, *)
+    wrapper.expects('downloadToStream)(clientSession, filename, *, *)
+    wrapper.expects('downloadToStream)(clientSession, filename, *, options, *)
+    wrapper.expects('downloadToStream)(clientSession, objectId, *, *)
+    wrapper.expects('downloadToStream)(clientSession, bsonValue, *, *)
 
     gridFSBucket.downloadToStream(filename, outputStream).head()
     gridFSBucket.downloadToStream(filename, outputStream, options).head()
     gridFSBucket.downloadToStream(objectId, outputStream).head()
     gridFSBucket.downloadToStream(bsonValue, outputStream).head()
+    gridFSBucket.downloadToStream(clientSession, filename, outputStream).head()
+    gridFSBucket.downloadToStream(clientSession, filename, outputStream, options).head()
+    gridFSBucket.downloadToStream(clientSession, objectId, outputStream).head()
+    gridFSBucket.downloadToStream(clientSession, bsonValue, outputStream).head()
   }
 
   it should "create the expected GridFSUploadStream" in {
@@ -153,11 +183,19 @@ class GridFSBucketSpec extends FlatSpec with Matchers with MockFactory {
     wrapper.expects('openUploadStream)(filename, options)
     wrapper.expects('openUploadStream)(bsonValue, filename)
     wrapper.expects('openUploadStream)(bsonValue, filename, options)
+    wrapper.expects('openUploadStream)(clientSession, filename)
+    wrapper.expects('openUploadStream)(clientSession, filename, options)
+    wrapper.expects('openUploadStream)(clientSession, bsonValue, filename)
+    wrapper.expects('openUploadStream)(clientSession, bsonValue, filename, options)
 
     gridFSBucket.openUploadStream(filename)
     gridFSBucket.openUploadStream(filename, options)
     gridFSBucket.openUploadStream(bsonValue, filename)
     gridFSBucket.openUploadStream(bsonValue, filename, options)
+    gridFSBucket.openUploadStream(clientSession, filename)
+    gridFSBucket.openUploadStream(clientSession, filename, options)
+    gridFSBucket.openUploadStream(clientSession, bsonValue, filename)
+    gridFSBucket.openUploadStream(clientSession, bsonValue, filename, options)
   }
 
   it should "uploadFromStream as expected" in {
@@ -170,11 +208,19 @@ class GridFSBucketSpec extends FlatSpec with Matchers with MockFactory {
     wrapper.expects('uploadFromStream)(filename, *, options, *)
     wrapper.expects('uploadFromStream)(bsonValue, filename, *, *)
     wrapper.expects('uploadFromStream)(bsonValue, filename, *, options, *)
+    wrapper.expects('uploadFromStream)(clientSession, filename, *, *)
+    wrapper.expects('uploadFromStream)(clientSession, filename, *, options, *)
+    wrapper.expects('uploadFromStream)(clientSession, bsonValue, filename, *, *)
+    wrapper.expects('uploadFromStream)(clientSession, bsonValue, filename, *, options, *)
 
     gridFSBucket.uploadFromStream(filename, inputStream).head()
     gridFSBucket.uploadFromStream(filename, inputStream, options).head()
     gridFSBucket.uploadFromStream(bsonValue, filename, inputStream).head()
     gridFSBucket.uploadFromStream(bsonValue, filename, inputStream, options).head()
+    gridFSBucket.uploadFromStream(clientSession, filename, inputStream).head()
+    gridFSBucket.uploadFromStream(clientSession, filename, inputStream, options).head()
+    gridFSBucket.uploadFromStream(clientSession, bsonValue, filename, inputStream).head()
+    gridFSBucket.uploadFromStream(clientSession, bsonValue, filename, inputStream, options).head()
   }
 
 }

--- a/driver/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -58,6 +58,10 @@ class AggregatesSpec extends FlatSpec with Matchers {
     toBson(bucket("$screenSize", 0, 24, 32, 50, 100000)) should equal(
       Document("""{$bucket: { groupBy: "$screenSize", boundaries: [0, 24, 32, 50, 100000] } } """)
     )
+
+    toBson(bucket("$screenSize", new BucketOptions().defaultBucket("other"), 0, 24, 32, 50, 100000)) should equal(
+      Document("""{$bucket: { groupBy: "$screenSize", boundaries: [0, 24, 32, 50, 100000], default: "other"} } """)
+    )
   }
 
   it should "render $bucketAuto" in {

--- a/driver/src/test/scala/org/mongodb/scala/model/FiltersSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/model/FiltersSpec.scala
@@ -37,12 +37,16 @@ class FiltersSpec extends FlatSpec with Matchers {
     val aliases = Set("equal", "notEqual", "bsonType")
     val ignore = Set("$anonfun$geoWithinPolygon$1")
     val local = model.Filters.getClass.getDeclaredMethods.filter(f => isPublic(f.getModifiers)).map(_.getName).toSet -- aliases -- ignore
+
     local should equal(wrapped)
   }
 
   it should "render without $eq" in {
     toBson(model.Filters.eq("x", 1)) should equal(Document("""{x : 1}"""))
     toBson(model.Filters.eq("x", null)) should equal(Document("""{x : null}"""))
+
+    toBson(model.Filters.equal("x", 1)) should equal(Document("""{x : 1}"""))
+    toBson(model.Filters.equal("x", null)) should equal(Document("""{x : null}"""))
   }
 
   it should "render $ne" in {
@@ -646,6 +650,14 @@ class FiltersSpec extends FlatSpec with Matchers {
                                                                                            }
                                                                                         }
                                                                                       }"""))
+  }
+
+  it should "render $expr" in {
+    toBson(model.Filters.expr(Document("{$gt: ['$spent', '$budget']}"))) should equal(Document("""{$expr: {$gt: ["$spent", "$budget"]}}"""))
+  }
+
+  it should "render $jsonSchema" in {
+    toBson(model.Filters.jsonSchema(Document("{bsonType: 'object'}"))) should equal(Document("""{$jsonSchema: {bsonType:  "object"}}"""))
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   // Versions
   val scalaVersions           = Seq("2.11.12", "2.12.4")
   val scalaCoreVersion        = "2.12.4"
-  val mongodbDriverVersion    = "3.5.0"
+  val mongodbDriverVersion    = "3.6.0"
 
   val scalaTestVersion        = "3.0.1"
   val scalaMockVersion        = "3.4.1"

--- a/project/scalastyle-config.xml
+++ b/project/scalastyle-config.xml
@@ -3,7 +3,7 @@
  <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+   <parameter name="maxFileLength"><![CDATA[1500]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">


### PR DESCRIPTION
Updated the Mongo Async Java Driver to 3.6.0 and updated
the API to match the new API.  This includes support for
Client Sessions, updates to List Databases and Aggregation.

SCALA-336