### PR TITLE
Ensure correct behaviour of ExecutionContextObservables

### DIFF
--- a/docs/reference/content/changelog.md
+++ b/docs/reference/content/changelog.md
@@ -14,6 +14,7 @@ Changes between released versions
   * Updated MongoDB Driver Async to 3.8.0.
   * Added transaction support. [SCALA-388](https://jira.mongodb.org/browse/SCALA-388)
   * Added `MongoCredential.createScramSha256Credential`. [SCALA-375](https://jira.mongodb.org/browse/SCALA-375)
+  * Fixed `ExecutionContextObservable` race condition regarding ordering of Observer calls. [SCALA-405](https://jira.mongodb.org/browse/SCALA-405]
   * `FindObservable.maxScan` deprecated. [SCALA-385](https://jira.mongodb.org/browse/SCALA-385)
   * `FindObservable.snapshot` deprecated. [SCALA-386](https://jira.mongodb.org/browse/SCALA-386)
   * `MongoCredential.createMongoCRCredential` deprecated. [SCALA-371](https://jira.mongodb.org/browse/SCALA-371)


### PR DESCRIPTION
As it uses an ExecutionContext there can be a race condition between
calls of the methods.  onSubscribe and onNext need to block to ensure
that they have been processed before allowing further calls to the
Observable. onError and onComplete do not need to block as they are
by contract terminal methods on the observer.

SCALA-405