### PR TITLE
Ensure correct behaviour of ExecutionContextObservables

### DIFF
--- a/docs/reference/content/changelog.md
+++ b/docs/reference/content/changelog.md
@@ -15,6 +15,7 @@ Changes between released versions
   * Added transaction support. [SCALA-388](https://jira.mongodb.org/browse/SCALA-388)
   * Added `MongoCredential.createScramSha256Credential`. [SCALA-375](https://jira.mongodb.org/browse/SCALA-375)
   * Updated CaseClassCodec error catching for unsupported types. [SCALA-343](https://jira.mongodb.org/browse/SCALA-343)
+  * Fixed `ExecutionContextObservable` race condition regarding ordering of Observer calls. [SCALA-405](https://jira.mongodb.org/browse/SCALA-405]
   * `FindObservable.maxScan` deprecated. [SCALA-385](https://jira.mongodb.org/browse/SCALA-385)
   * `FindObservable.snapshot` deprecated. [SCALA-386](https://jira.mongodb.org/browse/SCALA-386)
   * `MongoCredential.createMongoCRCredential` deprecated. [SCALA-371](https://jira.mongodb.org/browse/SCALA-371)

--- a/driver/src/main/scala/org/mongodb/scala/ObservableImplicits.scala
+++ b/driver/src/main/scala/org/mongodb/scala/ObservableImplicits.scala
@@ -391,7 +391,7 @@ trait ObservableImplicits {
      * @param context the execution context
      * @return an Observable that uses the specified execution context
      */
-    def observeOn(context: ExecutionContext): Observable[T] = ExecutionContextObservable(context, observable)
+    def observeOn(context: ExecutionContext): Observable[T] = ExecutionContextObservable(observable, context)
 
   }
 

--- a/driver/src/main/scala/org/mongodb/scala/internal/ExecutionContextObservable.scala
+++ b/driver/src/main/scala/org/mongodb/scala/internal/ExecutionContextObservable.scala
@@ -16,32 +16,70 @@
 
 package org.mongodb.scala.internal
 
-import scala.concurrent.ExecutionContext
+import java.util.concurrent.ConcurrentLinkedQueue
 
 import org.mongodb.scala.{Observable, Observer, Subscription}
 
-private[scala] case class ExecutionContextObservable[T](context: ExecutionContext, original: Observable[T]) extends Observable[T] {
+import scala.concurrent.ExecutionContext
 
+private[scala] case class ExecutionContextObservable[T](observable: Observable[T], context: ExecutionContext) extends Observable[T] {
+
+  // scalastyle:off method.length
   override def subscribe(observer: Observer[_ >: T]): Unit = {
-    original.subscribe(SubscriptionCheckingObserver(
+    observable.subscribe(SubscriptionCheckingObserver(
       new Observer[T] {
-        override def onError(throwable: Throwable): Unit = context.execute(new Runnable {
-          override def run() = observer.onError(throwable)
+        private val queue = new ConcurrentLinkedQueue[T]()
+        @volatile
+        private var onSubscribeCalled = false
+        @volatile
+        private var error: Option[Throwable] = None
+        @volatile
+        private var onCompleteCalled = false
+
+        override def onSubscribe(subscription: Subscription): Unit = withContext(() => {
+          onSubscribeCalled = true
+          observer.onSubscribe(subscription)
+          processAction()
         })
 
-        override def onSubscribe(subscription: Subscription): Unit = context.execute(new Runnable {
-          override def run() = observer.onSubscribe(subscription)
-        })
+        override def onNext(tResult: T): Unit = {
+          queue.add(tResult)
+          processAction()
+        }
 
-        override def onComplete(): Unit = context.execute(new Runnable {
-          override def run() = observer.onComplete()
-        })
+        override def onError(throwable: Throwable): Unit = {
+          error = Some(throwable)
+          processAction()
+        }
 
-        override def onNext(tResult: T): Unit = context.execute(new Runnable {
-          override def run() = observer.onNext(tResult)
-        })
+        override def onComplete(): Unit = {
+          onCompleteCalled = true
+          processAction()
+        }
+
+        def processAction(): Unit = synchronized {
+          if (!onSubscribeCalled) return // scalastyle:ignore
+          if (error.isDefined) {
+            withContext(() => observer.onError(error.get))
+          } else {
+            val next = queue.poll()
+            if (next != null) {
+              withContext(() => {
+                observer.onNext(next)
+                processAction()
+              })
+            } else if (onCompleteCalled) {
+              withContext(() => observer.onComplete())
+            }
+          }
+        }
+
+        private def withContext(f: () => Unit): Unit = {
+          context.execute(new Runnable {
+            override def run(): Unit = f()
+          })
+        }
       }
     ))
   }
 }
-

--- a/driver/src/test/scala/org/mongodb/scala/internal/ScalaObservableSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/internal/ScalaObservableSpec.scala
@@ -406,6 +406,11 @@ class ScalaObservableSpec extends FlatSpec with Matchers {
     Option(Await.result(TestObservable[Int](Observable(List[Int]())).head(), Duration(10, TimeUnit.SECONDS))) should equal(None)
   }
 
+  it should "not stackoverflow when using flatMap with execution contexts" in {
+    val altContextObservable = observable(1 to 10000).observeOn(ExecutionContext.global).flatMap((res: Int) => Observable(Seq(res)))
+    Await.result(altContextObservable.toFuture(), Duration(10, TimeUnit.SECONDS)) should equal(1 to 10000)
+  }
+
   it should "let the user know the Observable hasn't been subscribed to" in {
     forAll(observableErrorScenarios) { (obs: (() => Observable[_])) =>
       val futureError = intercept[IllegalStateException] {


### PR DESCRIPTION
As it uses an ExecutionContext there can be a race condition between
calls of the methods. Order of the observer methods need to be
maintained thus ensuring the Observable behaves as expected.

SCALA-405