### PR TITLE
Fix for Filter and Zip observables

### DIFF
--- a/driver/src/main/scala/org/mongodb/scala/internal/FilterObservable.scala
+++ b/driver/src/main/scala/org/mongodb/scala/internal/FilterObservable.scala
@@ -22,13 +22,32 @@ private[scala] case class FilterObservable[T](observable: Observable[T], p: T =>
   override def subscribe(observer: Observer[_ >: T]): Unit = {
     observable.subscribe(SubscriptionCheckingObserver(
       new Observer[T] {
-        override def onError(throwable: Throwable): Unit = observer.onError(throwable)
 
-        override def onSubscribe(subscription: Subscription): Unit = observer.onSubscribe(subscription)
+        @volatile private var terminated: Boolean = false
+        @volatile private var subscription: Option[Subscription] = None
 
-        override def onComplete(): Unit = observer.onComplete()
+        override def onError(throwable: Throwable): Unit = {
+          terminated = true
+          observer.onError(throwable)
+        }
 
-        override def onNext(tResult: T): Unit = if (p(tResult)) observer.onNext(tResult)
+        override def onSubscribe(subscription: Subscription): Unit = {
+          this.subscription = Some(subscription)
+          observer.onSubscribe(subscription)
+        }
+
+        override def onComplete(): Unit = {
+          terminated = true
+          observer.onComplete()
+        }
+
+        override def onNext(tResult: T): Unit = {
+          if (p(tResult)) {
+            observer.onNext(tResult)
+          } else if (!terminated) {
+            subscription.foreach(_.request(1)) // No match, request more from down stream
+          }
+        }
       }
     ))
   }

--- a/driver/src/main/scala/org/mongodb/scala/internal/ZipObservable.scala
+++ b/driver/src/main/scala/org/mongodb/scala/internal/ZipObservable.scala
@@ -35,10 +35,9 @@ private[scala] case class ZipObservable[T, U](
     private val thisQueue: ConcurrentLinkedQueue[(Long, T)] = new ConcurrentLinkedQueue[(Long, T)]()
     private val thatQueue: ConcurrentLinkedQueue[(Long, U)] = new ConcurrentLinkedQueue[(Long, U)]()
 
-    @volatile
-    private var observable1Subscription: Option[Subscription] = None
-    @volatile
-    private var observable2Subscription: Option[Subscription] = None
+    @volatile private var terminated: Boolean = false
+    @volatile private var observable1Subscription: Option[Subscription] = None
+    @volatile private var observable2Subscription: Option[Subscription] = None
 
     def createFirstObserver: Observer[T] = createSubObserver[T](thisQueue, observer, firstSub = true)
 
@@ -46,8 +45,11 @@ private[scala] case class ZipObservable[T, U](
 
     private def createSubObserver[A](queue: ConcurrentLinkedQueue[(Long, A)], observer: Observer[_ >: (T, U)], firstSub: Boolean): Observer[A] = {
       new Observer[A] {
-        var counter: Long = 0
-        override def onError(throwable: Throwable): Unit = observer.onError(throwable)
+        @volatile private var counter: Long = 0
+        override def onError(throwable: Throwable): Unit = {
+          terminated = true
+          observer.onError(throwable)
+        }
 
         override def onSubscribe(subscription: Subscription): Unit = {
           if (firstSub) {
@@ -62,13 +64,16 @@ private[scala] case class ZipObservable[T, U](
         }
 
         override def onComplete(): Unit = {
-          if (!firstSub) observer.onComplete()
+          if (!firstSub) {
+            terminated = true
+            observer.onComplete()
+          }
         }
 
         override def onNext(tResult: A): Unit = {
           counter += 1
           queue.add((counter, tResult))
-          processNext(observer)
+          if (!firstSub) processNext(observer)
         }
       }
     }
@@ -76,11 +81,12 @@ private[scala] case class ZipObservable[T, U](
     private def processNext(observer: Observer[_ >: (T, U)]): Unit = {
       (thisQueue.peek, thatQueue.peek) match {
         case ((k1: Long, _), (k2: Long, _)) if k1 == k2 => observer.onNext((thisQueue.poll()._2, thatQueue.poll()._2))
-        case _ => // Do nothing counters don't match
+        case _ => if (!terminated && !jointSubscription.isUnsubscribed) jointSubscription.request(1) // Uneven queues request more data
+        // from downstream so to honor the original request for data.
       }
     }
 
-    private val jointSubscription = new Subscription() {
+    private val jointSubscription: Subscription = new Subscription() {
       var subscribed: Boolean = true
       override def isUnsubscribed: Boolean = !subscribed
 
@@ -95,7 +101,6 @@ private[scala] case class ZipObservable[T, U](
         observable2Subscription.foreach(_.unsubscribe())
       }
     }
-
   }
 
 }

--- a/driver/src/test/scala/org/mongodb/scala/internal/ObservableImplementationSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/internal/ObservableImplementationSpec.scala
@@ -41,7 +41,7 @@ class ObservableImplementationSpec extends FlatSpec with Matchers with TableDriv
     }
   }
 
-  it should "Consuming observables should handl over requesting observables as expected" in {
+  it should "Consuming observables should handle over requesting observables as expected" in {
     forAll(overRequestingObservables) {
       (observable: Observable[Int], observer: TestObserver[Int], expected: Int) =>
         {
@@ -170,7 +170,7 @@ class ObservableImplementationSpec extends FlatSpec with Matchers with TableDriv
           val observer = TestObserver[(Int, Int)]()
           observable.subscribe(observer)
 
-          observer.subscription.get.request(100)
+          observer.subscription.foreach(_.request(100))
 
           observer.results should equal((1 to 50).map(i => (i, i)))
           observer.completed should equal(true)


### PR DESCRIPTION
Ensures that the Observable requests extra data when requested
data from down stream does not yield a result. Eg. When a filter
predicate fails or when there are uneven numbers when zipping two
observables together.

SCALA-457